### PR TITLE
Add new route_id values to support upcoming spring schedule API changes

### DIFF
--- a/public/js/data/blue.js
+++ b/public/js/data/blue.js
@@ -183,6 +183,6 @@ var stations = [{
 module.exports = {
   name: 'Blue Line',
   slug: 'blue',
-  routes: [ '946_', '948_' ],
+  routes: [ '946_', '948_', 'Blue' ],
   stops: stations
 };

--- a/public/js/data/orange.js
+++ b/public/js/data/orange.js
@@ -334,6 +334,6 @@ var stations = [{
 module.exports = {
   name: 'Orange Line',
   slug: 'orange',
-  routes: [ '901_', '913_' ],
+  routes: [ '901_', '913_', 'Orange' ],
   stops: stations
 };

--- a/public/js/data/red.js
+++ b/public/js/data/red.js
@@ -381,6 +381,6 @@ var stations = [{
 module.exports = {
   name: 'Red Line',
   slug: 'red',
-  routes: [ '931_', '933_' ],
+  routes: [ '931_', '933_', 'Red' ],
   stops: stations
 };

--- a/server/services/api/index.js
+++ b/server/services/api/index.js
@@ -17,10 +17,15 @@ var longCache = require( './_long-cache' );
 
 // Hard-coded route ID list (saves an otherwise useless DB round-trip)
 var routes = {
-  blue: [ '946_', '948_' ],
-  orange: [ '903_', '913_' ],
-  red: [ '931_', '933_' ],
-  green: [ '810_', '813_', '823_', '830_', '831_', '842_', '840_', '852_', '851_', '880_', '882_' ]
+  blue: [ '946_', '948_', 'Blue' ],
+  orange: [ '903_', '913_', 'Orange' ],
+  red: [ '931_', '933_', 'Red' ],
+  green: [
+    '810_', '813_', '823_', 'Green-B',
+    '830_', '831_', 'Green-C',
+    '842_', '840_', '851_', '852_', 'Green-D',
+    '880_', '882_', 'Green-E'
+  ]
 }
 
 /**


### PR DESCRIPTION
Per MBTA developer information released through the massdotdevelopers google group (https://groups.google.com/forum/#!topic/massdotdevelopers/kXJuTRqtdfQ), the realtime API will be changing on March 21: new route_id values will be returned (e.g. "Red" instead of "931_" and "933_") in the realtime API output. This change should make this API update transparent to MBTAwesome end users.
