### PR TITLE
Remove empty alerts arrays from API response (fixes #33)

### DIFF
--- a/server/services/api/index.js
+++ b/server/services/api/index.js
@@ -109,6 +109,8 @@ function alertsByLine( lineSlug ) {
       .pluck( 'alerts' )
       // Flatten alerts from multiple routes into a single array
       .flatten()
+      // Remove leftovers from empty alerts arrays
+      .filter()
       // De-dupe on ID (one alert can affect many lines, and may be returned twice)
       .unique( 'alert_id' )
       .value()


### PR DESCRIPTION
The alerts endpoint was failing because the API was returning empty alerts arrays, which lead to undefined values unless we filter our flattened array.
