### PR TITLE
Allow trip predictions list to expand/collapse

### DIFF
--- a/public/js/routes/station-detail/collections/direction-predictions.js
+++ b/public/js/routes/station-detail/collections/direction-predictions.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var Collection = require( 'ampersand-collection' );
+var DirectionPredictionsModel = require( '../models/direction-predictions' );
+
+var DirectionPredictionsCollection = Collection.extend({
+  model: DirectionPredictionsModel
+});
+
+module.exports = DirectionPredictionsCollection;

--- a/public/js/routes/station-detail/models/direction-predictions.js
+++ b/public/js/routes/station-detail/models/direction-predictions.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var Model = require( 'ampersand-model' );
+
+var DirectionPredictionsModel = Model.extend({
+  props: {
+    /**
+     * The name of the direction of travel for this prediction
+     * @property {String} name
+     */
+    name: 'string',
+    /**
+     * The trips going in this direction for which we have predictions
+     * @property {Array} trips
+     */
+    trips: 'array'
+  },
+
+  initialize: function() {
+    console.log( this.getAttributes() );
+  }
+});
+
+module.exports = DirectionPredictionsModel;

--- a/public/js/routes/station-detail/models/direction-predictions.js
+++ b/public/js/routes/station-detail/models/direction-predictions.js
@@ -14,10 +14,6 @@ var DirectionPredictionsModel = Model.extend({
      * @property {Array} trips
      */
     trips: 'array'
-  },
-
-  initialize: function() {
-    console.log( this.getAttributes() );
   }
 });
 

--- a/public/js/routes/station-detail/station-detail.tmpl
+++ b/public/js/routes/station-detail/station-detail.tmpl
@@ -8,42 +8,7 @@
 
   <hr class="divider-{{ line.slug }}" />
 
-  <ul class="arrival-predictions {{ line.slug }}">
-    {%each tripsByDirection as direction %}
-    <li>
-      <h3>{{ direction.name }}</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>
-              <acronym title="Estimated Time of Arrival">ETA</acronym>
-            </th>
-            <th>Destination</th>
-          </tr>
-        </thead>
-        <tbody>
-
-        {%-- TODO: add loading indicator --%}
-        {%if direction.trips.length %}
-          {%each direction.trips as trip %}
-          <tr {{ 'class="scheduled"' if trip.scheduled }}>
-            <td>{{ trip.timeUntil }}</td>
-            <td>{{ trip.headsign }}</td>
-          </tr>
-          {%endeach %}
-        {%else %}
-          <tr>
-            <td colspan="2">
-              <em>No trains in service</em>
-            </td>
-          </tr>
-        {%endif %}
-        </tbody>
-      </table>
-    </li>
-    {%endeach %}
-  </ul>
+  <ul class="arrival-predictions {{ line.slug }}" data-hook="predictions-lists"></ul>
 
   {%if station.transfer %}
   <p class="transfers">

--- a/public/js/routes/station-detail/trip-predictions-list-view.js
+++ b/public/js/routes/station-detail/trip-predictions-list-view.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var bind = require( 'lodash.bind' );
+var jQueryView = require( '../../views/jq-view' );
+var predictionsListTemplate = require( './trip-predictions-list.tmpl' );
+
+var PredictionsListView = jQueryView.extend({
+
+  autoRender: true,
+
+  template: bind( predictionsListTemplate.render, predictionsListTemplate ),
+
+  // Use derived properties to keep template cleaner
+  derived: {
+    name: {
+      deps: [ 'model.name' ],
+      fn: function() {
+        return this.model.name;
+      }
+    },
+    trips: {
+      deps: [ 'model.trips' ],
+      fn: function() {
+        return this.model.trips;
+      }
+    }
+  }
+
+});
+
+module.exports = PredictionsListView;

--- a/public/js/routes/station-detail/trip-predictions-list-view.js
+++ b/public/js/routes/station-detail/trip-predictions-list-view.js
@@ -23,7 +23,40 @@ var PredictionsListView = jQueryView.extend({
       fn: function() {
         return this.model.trips;
       }
+    },
+    moreTripsAvailable: {
+      deps: [ 'trips' ],
+      fn: function() {
+        return this.trips.length > 2;
+      }
+    },
+    tripsPreview: {
+      deps: [ 'trips' ],
+      fn: function() {
+        return this.trips.slice( 0, 2 );
+      }
     }
+  },
+
+  session: {
+    /**
+     * Whether the list of predictions is expanded (view state property)
+     *
+     * @type {String} expanded
+     */
+    expanded: 'boolean'
+  },
+
+  events: {
+    'click .toggle': 'toggleListExpansion'
+  },
+
+  toggleListExpansion: function() {
+    this.expanded = ! this.expanded;
+  },
+
+  initialize: function() {
+    this.on( 'change:expanded', this.render );
   }
 
 });

--- a/public/js/routes/station-detail/trip-predictions-list.tmpl
+++ b/public/js/routes/station-detail/trip-predictions-list.tmpl
@@ -1,7 +1,7 @@
 <li>
   <h3>{{ name }}</h3>
 
-  <table>
+  <table {%if moreTripsAvailable %}class="toggle"{%endif %}>
     <thead>
       <tr>
         <th>
@@ -14,12 +14,34 @@
 
     {%-- TODO: add loading indicator --%}
     {%if trips.length %}
-      {%each trips as trip %}
-      <tr {{ 'class="scheduled"' if trip.scheduled }}>
-        <td>{{ trip.timeUntil }}</td>
-        <td>{{ trip.headsign }}</td>
+      {%if not expanded %}
+        {%each tripsPreview as trip %}
+        <tr {{ 'class="scheduled"' if trip.scheduled }}>
+          <td>{{ trip.timeUntil }}</td>
+          <td>{{ trip.headsign }}</td>
+        </tr>
+        {%endeach %}
+      {%else %}
+        {%each trips as trip %}
+        <tr {{ 'class="scheduled"' if trip.scheduled }}>
+          <td>{{ trip.timeUntil }}</td>
+          <td>{{ trip.headsign }}</td>
+        </tr>
+        {%endeach %}
+      {%endif %}
+      {%if moreTripsAvailable %}
+      <tr>
+        <td colspan="2" class="list-expander">
+          <button>
+          {%if not expanded %}
+            Show All Upcoming Trips
+          {%else %}
+            Collapse
+          {%endif %}
+          </button>
+        </td>
       </tr>
-      {%endeach %}
+      {%endif %}
     {%else %}
       <tr>
         <td colspan="2">

--- a/public/js/routes/station-detail/trip-predictions-list.tmpl
+++ b/public/js/routes/station-detail/trip-predictions-list.tmpl
@@ -1,0 +1,33 @@
+<li>
+  <h3>{{ name }}</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>
+          <acronym title="Estimated Time of Arrival">ETA</acronym>
+        </th>
+        <th>Destination</th>
+      </tr>
+    </thead>
+    <tbody>
+
+    {%-- TODO: add loading indicator --%}
+    {%if trips.length %}
+      {%each trips as trip %}
+      <tr {{ 'class="scheduled"' if trip.scheduled }}>
+        <td>{{ trip.timeUntil }}</td>
+        <td>{{ trip.headsign }}</td>
+      </tr>
+      {%endeach %}
+    {%else %}
+      <tr>
+        <td colspan="2">
+          <em>No trains in service</em>
+        </td>
+      </tr>
+    {%endif %}
+    </tbody>
+
+  </table>
+</li>

--- a/public/stylus/app.styl
+++ b/public/stylus/app.styl
@@ -397,6 +397,14 @@ xfer-border( $color, $color2 = $color ) {
     padding-bottom: 10px;
   }
 
+  .list-expander {
+    border-bottom: 0;
+
+    button {
+      max-width: 100%;
+    }
+  }
+
   th {
     padding-top: 0;
     padding-bottom: 10px;


### PR DESCRIPTION
Fixes #35, to permit easier scanning of upcoming trips in both directions
