### PR TITLE
Add more fixtures & improve fixture infrastructure

### DIFF
--- a/bin/debug
+++ b/bin/debug
@@ -22,7 +22,7 @@ if ( _.isString( argv.f ) ) {
 var Replay = require( 'replay' );
 // Use the fixture set specified in the config
 var path = require( 'path' );
-Replay.fixtures = path.join( __dirname, '../fixtures/' + config.api.fixtures );
+Replay.fixtures = path.join( __dirname, '../fixtures/' + fixtureDir );
 
 // Optionally set record mode from the CLI
 if ( process.argv.record || process.argv.r ) {

--- a/bin/debug
+++ b/bin/debug
@@ -1,19 +1,36 @@
 #!/usr/bin/env node
 var debug = require( 'debug' )( 'init' );
 var app = require( '../server' );
+var _ = require( 'lodash' );
+
+// Get any command-line arguments
+var argv = require( 'minimist' )( process.argv.slice( 2 ) );
+
+// Use data fixtures: Configure Replay behavior based on config
+// or command-line parameters (e.g. debug --fixture=normal-service)
+var config = require( '../server/services/config' );
+var fixtureDir;
+if ( _.isString( argv.f ) ) {
+  fixtureDir = argv.f;
+} else if ( _.isString( argv.fixture ) ) {
+  fixtureDir = argv.fixture;
+} else {
+  fixtureDir = config.api.fixtures;
+}
+
+// Set up replay to mock API with the selected fixtures
+var Replay = require( 'replay' );
+// Use the fixture set specified in the config
+var path = require( 'path' );
+Replay.fixtures = path.join( __dirname, '../fixtures/' + config.api.fixtures );
+
+// Optionally set record mode from the CLI
+if ( process.argv.record || process.argv.r ) {
+  Replay.mode = 'record';
+}
 
 app.set( 'port', process.env.PORT || 3000 );
 
 var server = app.listen( app.get( 'port' ), function() {
   debug( 'Express server listening on port ' + server.address().port );
 });
-
-// Use data fixtures: Configure Replay behavior based on config
-// Get application config
-var config = require( '../server/services/config' );
-
-// Set up replay to mock API with fixtures if config.api.replay is true
-var Replay = require( 'replay' );
-// Use the fixture set specified in the config
-var path = require( 'path' );
-Replay.fixtures = path.join( __dirname, '../fixtures/' + config.api.fixtures );

--- a/bin/debug
+++ b/bin/debug
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var debug = require( 'debug' )( 'init' );
-var app = require( '../server' );
 var _ = require( 'lodash' );
 
 // Get any command-line arguments
@@ -25,11 +24,25 @@ var path = require( 'path' );
 Replay.fixtures = path.join( __dirname, '../fixtures/' + fixtureDir );
 
 // Optionally set record mode from the CLI
-if ( process.argv.record || process.argv.r ) {
+if ( argv.record || argv.r ) {
+  console.log( 'Recording fixture "' + fixtureDir + '"...' );
   Replay.mode = 'record';
+} else {
+  console.log( 'Replaying fixture "' + fixtureDir + '"...' );
+  config.api.key = 'wX9NwuHnZU2ToO7GmGR9uw';
 }
 
-app.set( 'port', process.env.PORT || 3000 );
+// Require in, configure & load the server
+var app = require( '../server' );
+var port = 3000;
+if ( process.env.PORT ) {
+  port = process.env.PORT;
+} else if ( _.isString( argv.p ) ) {
+  port = argv.p;
+} else if ( _.isString( argv.port ) ) {
+  port = argv.port;
+}
+app.set( 'port', port );
 
 var server = app.listen( app.get( 'port' ), function() {
   debug( 'Express server listening on port ' + server.address().port );

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-blue.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-blue.fixture
@@ -1,0 +1,116 @@
+GET /developer/api/v2/alertsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:09 GMT
+connection: close
+content-length: 3901
+
+{
+  "alerts": [{
+    "alert_id": 93195,
+    "effect_name": "Service Change",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/riding_the_t/default.asp?id=26899",
+    "description_text": "As part of the project to make Government Center Station fully accessible, all passengers will board and exit on the westbound platform at Bowdoin Station from start to end of service during the following weekends:\r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015\r\n\r\nThe eastbound platform at Bowdoin will be available the following Mondays. The Government Center shuttle bus between State, Government Center, Bowdoin, and Haymarket is unaffected by this service change.\r\n\r\nAffected stops:\r\nBowdoin",
+    "severity": "Minor",
+    "created_dt": "1441904256",
+    "last_modified_dt": "1441904256",
+    "service_effect_text": "Blue Line notice",
+    "timeframe_text": "through September 27",
+    "alert_lifecycle": "New",
+    "recurrence_text": "weekends",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442125800"
+    }, {
+      "effect_start": "1442133000",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442651400",
+      "effect_end": "1442730600"
+    }, {
+      "effect_start": "1442737800",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1443256200",
+      "effect_end": "1443335400"
+    }, {
+      "effect_start": "1443342600",
+      "effect_end": "1443421800"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Blue",
+        "route_name": "Blue Line",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 93195,
+    "effect_name": "Service Change",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/riding_the_t/default.asp?id=26899",
+    "description_text": "As part of the project to make Government Center Station fully accessible, all passengers will board and exit on the westbound platform at Bowdoin Station from start to end of service during the following weekends:\r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015\r\n\r\nThe eastbound platform at Bowdoin will be available the following Mondays. The Government Center shuttle bus between State, Government Center, Bowdoin, and Haymarket is unaffected by this service change.\r\n\r\nAffected stops:\r\nBowdoin",
+    "severity": "Minor",
+    "created_dt": "1441904256",
+    "last_modified_dt": "1441904256",
+    "service_effect_text": "Blue Line notice",
+    "timeframe_text": "through September 27",
+    "alert_lifecycle": "New",
+    "recurrence_text": "weekends",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442125800"
+    }, {
+      "effect_start": "1442133000",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442651400",
+      "effect_end": "1442730600"
+    }, {
+      "effect_start": "1442737800",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1443256200",
+      "effect_end": "1443335400"
+    }, {
+      "effect_start": "1443342600",
+      "effect_end": "1443421800"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Blue",
+        "route_name": "Blue Line",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Blue",
+  "route_name": "Blue Line"
+}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-b.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-b.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-B&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:11 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-B","route_name":"Green Line B"}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-c.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-c.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-C&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:11 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-C","route_name":"Green Line C"}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-d.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-d.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-D&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:11 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-D","route_name":"Green Line D"}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-e.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-green-e.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-E&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:11 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-E","route_name":"Green Line E"}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-orange.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-orange.fixture
@@ -1,0 +1,289 @@
+GET /developer/api/v2/alertsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:08 GMT
+connection: close
+content-length: 9006
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90254,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Oak Grove and Sullivan Stations on September 13-17, 20-24, and 27-30 as well as October 1, 4-8, 11-15, 19-22, and 25-29 from approximately 8:45 p.m. through the end of service",
+    "short_header_text": "Buses replacing Orange Ln between Oak Grove & Sullivan on Sep 13-17, 20-24, & 27-30 & Oct 1, 4-8, 11-15, 19-22, & 25-29 from about 8:45pm un",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing work as part of the Winter Resiliency Improvement Program, alternate shuttle buses will replace Orange Line trains in both directions from Sullivan to Oak Grove Stations beginning at approximately 8:45 p.m. through the end of service on the following dates: \r\n\r\n- Sunday, September 13, 2015, through Thursday, September 17, 2015. \r\n- Sunday, September 20, 2015, through Thursday, September 24, 2015. \r\n- Sunday, September 27, 2015, through Thursday, October 1, 2015.\r\n- Sunday, October 4, 2015, through Thursday, October 8, 2015.\r\n- Sunday, October 11, 2015, through Thursday, October 15, 2015\r\n- Monday, October 19, 2015, through Thursday, October 22, 2015\r\n- Sunday, October 25, 2015, through Thursday, October 29, 2015.\r\n\r\nRegular Orange Line trains will resume at the start of service the next day. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nOak Grove\r\nMalden Center\r\nWellington\r\nAssembly\r\nSullivan Square",
+    "severity": "Severe",
+    "created_dt": "1439849389",
+    "last_modified_dt": "1441969989",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "starting tomorrow",
+    "alert_lifecycle": "Upcoming",
+    "recurrence_text": "Sunday-Thursday",
+    "effect_periods": [{
+      "effect_start": "1442191500",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442277900",
+      "effect_end": "1442298600"
+    }, {
+      "effect_start": "1442364300",
+      "effect_end": "1442385000"
+    }, {
+      "effect_start": "1442450700",
+      "effect_end": "1442471400"
+    }, {
+      "effect_start": "1442537100",
+      "effect_end": "1442557800"
+    }, {
+      "effect_start": "1442796300",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1442882700",
+      "effect_end": "1442903400"
+    }, {
+      "effect_start": "1442969100",
+      "effect_end": "1442989800"
+    }, {
+      "effect_start": "1443055500",
+      "effect_end": "1443076200"
+    }, {
+      "effect_start": "1443141900",
+      "effect_end": "1443162600"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 92997,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "short_header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Orange Line trains between Forest Hills and Ruggles Stations in both directions from start to end of service beginning Saturday, October 17, through Sunday, October 18. Regular Red Line train service will resume at the start of service on Monday, October 19. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops: \r\nRuggles\r\nRoxbury Crossing\r\nJackson Square\r\nStony Brook\r\nGreen Street\r\nForest Hills",
+    "severity": "Severe",
+    "created_dt": "1441809730",
+    "last_modified_dt": "1441809730",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "October 17-18",
+    "alert_lifecycle": "Upcoming",
+    "effect_periods": [{
+      "effect_start": "1445070600",
+      "effect_end": "1445236200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Orange",
+  "route_name": "Orange Line"
+}

--- a/fixtures/bad-sequencing/realtime.mbta.com/alerts-red.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/alerts-red.fixture
@@ -1,0 +1,167 @@
+GET /developer/api/v2/alertsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:12:58 GMT
+connection: close
+content-length: 5235
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90418,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Red Line trains between JFK/UMass and Quincy Center Stations in both directions from start to end of service during the following weekends: \r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015.\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015.\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015. \r\n\r\nRegular Red Line train service will resume at the start of service on Mondays. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nJFK/UMass\r\nNorth Quincy\r\nWollaston\r\nQuincy Center",
+    "severity": "Severe",
+    "created_dt": "1439993541",
+    "last_modified_dt": "1442051715",
+    "service_effect_text": "Red Line shuttle",
+    "timeframe_text": "this weekend",
+    "alert_lifecycle": "New",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442212200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70086",
+        "stop_name": "JFK/UMASS Ashmont - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70095",
+        "stop_name": "JFK/UMASS Braintree - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70096",
+        "stop_name": "JFK/UMASS Braintree - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70098",
+        "stop_name": "North Quincy - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70100",
+        "stop_name": "Wollaston - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70102",
+        "stop_name": "Quincy Center - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Red",
+  "route_name": "Red Line"
+}

--- a/fixtures/bad-sequencing/realtime.mbta.com/predictions-blue.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/predictions-blue.fixture
@@ -1,0 +1,702 @@
+GET /developer/api/v2/predictionsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:09 GMT
+connection: close
+content-length: 14334
+
+{
+  "route_id": "Blue",
+  "route_name": "Blue Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Westbound",
+    "trip": [{
+      "trip_id": "28188900",
+      "trip_name": "10:06 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "vehicle": {
+        "vehicle_id": "0773",
+        "vehicle_lat": "42.36581",
+        "vehicle_lon": "-71.04263",
+        "vehicle_bearing": "215",
+        "vehicle_timestamp": "1442067157"
+      },
+      "stop": [{
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067225",
+        "pre_away": "40"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067352",
+        "pre_away": "167"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067523",
+        "pre_away": "338"
+      }]
+    }, {
+      "trip_id": "28188698",
+      "trip_name": "10:15 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "vehicle": {
+        "vehicle_id": "0786",
+        "vehicle_lat": "42.40776",
+        "vehicle_lon": "-70.99253",
+        "vehicle_bearing": "170",
+        "vehicle_timestamp": "1442067140"
+      },
+      "stop": [{
+        "stop_sequence": "20",
+        "stop_id": "70055",
+        "stop_name": "Beachmont - Inbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067269",
+        "pre_away": "84"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70053",
+        "stop_name": "Suffolk Downs - Inbound",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067356",
+        "pre_away": "171"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70051",
+        "stop_name": "Orient Heights - Inbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067450",
+        "pre_away": "265"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70049",
+        "stop_name": "Wood Island - Inbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067641",
+        "pre_away": "456"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70047",
+        "stop_name": "Airport - Inbound",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067744",
+        "pre_away": "559"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70045",
+        "stop_name": "Maverick - Inbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442067891",
+        "pre_away": "706"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068045",
+        "pre_away": "860"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068172",
+        "pre_away": "987"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068343",
+        "pre_away": "1158"
+      }]
+    }, {
+      "trip_id": "28188732",
+      "trip_name": "10:24 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067720",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70057",
+        "stop_name": "Revere Beach - Inbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067755",
+        "pre_away": "570"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70055",
+        "stop_name": "Beachmont - Inbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442067884",
+        "pre_away": "699"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70053",
+        "stop_name": "Suffolk Downs - Inbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442067971",
+        "pre_away": "786"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70051",
+        "stop_name": "Orient Heights - Inbound",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068065",
+        "pre_away": "880"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70049",
+        "stop_name": "Wood Island - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068256",
+        "pre_away": "1071"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70047",
+        "stop_name": "Airport - Inbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068359",
+        "pre_away": "1174"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70045",
+        "stop_name": "Maverick - Inbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068506",
+        "pre_away": "1321"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068661",
+        "pre_away": "1476"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442068788",
+        "pre_away": "1603"
+      }]
+    }, {
+      "trip_id": "28188776",
+      "trip_name": "10:32 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068320",
+        "pre_away": "1135"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70057",
+        "stop_name": "Revere Beach - Inbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068355",
+        "pre_away": "1170"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70055",
+        "stop_name": "Beachmont - Inbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068484",
+        "pre_away": "1299"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70053",
+        "stop_name": "Suffolk Downs - Inbound",
+        "sch_arr_dt": "1442068560",
+        "sch_dep_dt": "1442068560",
+        "pre_dt": "1442068571",
+        "pre_away": "1386"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70051",
+        "stop_name": "Orient Heights - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068665",
+        "pre_away": "1480"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70049",
+        "stop_name": "Wood Island - Inbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068856",
+        "pre_away": "1671"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70047",
+        "stop_name": "Airport - Inbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068959",
+        "pre_away": "1774"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70045",
+        "stop_name": "Maverick - Inbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442069106",
+        "pre_away": "1921"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069261",
+        "pre_away": "2076"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442069160",
+        "sch_dep_dt": "1442069160",
+        "pre_dt": "1442069388",
+        "pre_away": "2203"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Eastbound",
+    "trip": [{
+      "trip_id": "28188731",
+      "trip_name": "9:55 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "vehicle": {
+        "vehicle_id": "0777",
+        "vehicle_lat": "42.39856",
+        "vehicle_lon": "-70.99172",
+        "vehicle_bearing": "15",
+        "vehicle_timestamp": "1442067176"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442067240",
+        "sch_dep_dt": "1442067240",
+        "pre_dt": "1442067280",
+        "pre_away": "95"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067385",
+        "pre_away": "200"
+      }]
+    }, {
+      "trip_id": "28188775",
+      "trip_name": "10:03 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "vehicle": {
+        "vehicle_id": "0741",
+        "vehicle_lat": "42.36924",
+        "vehicle_lon": "-71.03943",
+        "vehicle_bearing": "35",
+        "vehicle_timestamp": "1442067176"
+      },
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442067000",
+        "sch_dep_dt": "1442067000",
+        "pre_dt": "1442067324",
+        "pre_away": "139"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067426",
+        "pre_away": "241"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067600",
+        "pre_away": "415"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442067480",
+        "sch_dep_dt": "1442067480",
+        "pre_dt": "1442067686",
+        "pre_away": "501"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067770",
+        "pre_away": "585"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067914",
+        "pre_away": "729"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442068019",
+        "pre_away": "834"
+      }]
+    }, {
+      "trip_id": "28188857",
+      "trip_name": "10:21 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067660",
+        "pre_away": "475"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067757",
+        "pre_away": "572"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067861",
+        "pre_away": "676"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442068005",
+        "pre_away": "820"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068153",
+        "pre_away": "968"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068255",
+        "pre_away": "1070"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068429",
+        "pre_away": "1244"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442068560",
+        "sch_dep_dt": "1442068560",
+        "pre_dt": "1442068515",
+        "pre_away": "1330"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442068599",
+        "pre_away": "1414"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068742",
+        "pre_away": "1557"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068847",
+        "pre_away": "1662"
+      }]
+    }, {
+      "trip_id": "28188901",
+      "trip_name": "10:29 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068140",
+        "pre_away": "955"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068237",
+        "pre_away": "1052"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068341",
+        "pre_away": "1156"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068485",
+        "pre_away": "1300"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442068560",
+        "sch_dep_dt": "1442068560",
+        "pre_dt": "1442068633",
+        "pre_away": "1448"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068735",
+        "pre_away": "1550"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068909",
+        "pre_away": "1724"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442069040",
+        "sch_dep_dt": "1442069040",
+        "pre_dt": "1442068995",
+        "pre_away": "1810"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442069160",
+        "sch_dep_dt": "1442069160",
+        "pre_dt": "1442069079",
+        "pre_away": "1894"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442069222",
+        "pre_away": "2037"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442069400",
+        "sch_dep_dt": "1442069400",
+        "pre_dt": "1442069327",
+        "pre_away": "2142"
+      }]
+    }, {
+      "trip_id": "28188699",
+      "trip_name": "10:38 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442068680",
+        "pre_away": "1495"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068777",
+        "pre_away": "1592"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068881",
+        "pre_away": "1696"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442069025",
+        "pre_away": "1840"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069173",
+        "pre_away": "1988"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442069275",
+        "pre_away": "2090"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069449",
+        "pre_away": "2264"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442069580",
+        "sch_dep_dt": "1442069580",
+        "pre_dt": "1442069535",
+        "pre_away": "2350"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069619",
+        "pre_away": "2434"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442069820",
+        "sch_dep_dt": "1442069820",
+        "pre_dt": "1442069762",
+        "pre_away": "2577"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442069940",
+        "sch_dep_dt": "1442069940",
+        "pre_dt": "1442069867",
+        "pre_away": "2682"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 93195,
+    "header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "effect_name": "Service Change"
+  }]
+}

--- a/fixtures/bad-sequencing/realtime.mbta.com/predictions-orange.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/predictions-orange.fixture
@@ -1,0 +1,1550 @@
+GET /developer/api/v2/predictionsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:13:08 GMT
+connection: close
+content-length: 33234
+
+{
+  "route_id": "Orange",
+  "route_name": "Orange Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28191093",
+      "trip_name": "9:45 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1286",
+        "vehicle_lat": "42.33653",
+        "vehicle_lon": "-71.0897",
+        "vehicle_bearing": "220",
+        "vehicle_timestamp": "1442067145"
+      },
+      "stop": [{
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442067000",
+        "sch_dep_dt": "1442067000",
+        "pre_dt": "1442067243",
+        "pre_away": "58"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442067060",
+        "sch_dep_dt": "1442067060",
+        "pre_dt": "1442067341",
+        "pre_away": "156"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067450",
+        "pre_away": "265"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067544",
+        "pre_away": "359"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067684",
+        "pre_away": "499"
+      }]
+    }, {
+      "trip_id": "28191094",
+      "trip_name": "9:55 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1302",
+        "vehicle_lat": "42.35346",
+        "vehicle_lon": "-71.06241",
+        "vehicle_bearing": "195",
+        "vehicle_timestamp": "1442067171"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442067120",
+        "sch_dep_dt": "1442067120",
+        "pre_dt": "1442067181",
+        "pre_away": "3"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067260",
+        "pre_away": "75"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067377",
+        "pre_away": "192"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067517",
+        "pre_away": "332"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067601",
+        "pre_away": "416"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067699",
+        "pre_away": "514"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067797",
+        "pre_away": "612"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067906",
+        "pre_away": "721"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442068000",
+        "pre_away": "815"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442068140",
+        "pre_away": "955"
+      }]
+    }, {
+      "trip_id": "28191095",
+      "trip_name": "10:05 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1275",
+        "vehicle_lat": "42.38868",
+        "vehicle_lon": "-71.07706",
+        "vehicle_bearing": "175",
+        "vehicle_timestamp": "1442067178"
+      },
+      "stop": [{
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067228",
+        "pre_away": "43"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067362",
+        "pre_away": "177"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067501",
+        "pre_away": "316"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442067480",
+        "sch_dep_dt": "1442067480",
+        "pre_dt": "1442067580",
+        "pre_away": "395"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067673",
+        "pre_away": "488"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067764",
+        "pre_away": "579"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067854",
+        "pre_away": "669"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067933",
+        "pre_away": "748"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442068050",
+        "pre_away": "865"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442068190",
+        "pre_away": "1005"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068274",
+        "pre_away": "1089"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442068372",
+        "pre_away": "1187"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068470",
+        "pre_away": "1285"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068579",
+        "pre_away": "1394"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068673",
+        "pre_away": "1488"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068813",
+        "pre_away": "1628"
+      }]
+    }, {
+      "trip_id": "28191096",
+      "trip_name": "10:15 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1285",
+        "vehicle_lat": "42.43464",
+        "vehicle_lon": "-71.07132",
+        "vehicle_bearing": "185",
+        "vehicle_timestamp": "1442067166"
+      },
+      "stop": [{
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067253",
+        "pre_away": "68"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067474",
+        "pre_away": "289"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067607",
+        "pre_away": "422"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067727",
+        "pre_away": "542"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067861",
+        "pre_away": "676"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442068000",
+        "pre_away": "815"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068079",
+        "pre_away": "894"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068172",
+        "pre_away": "987"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442068263",
+        "pre_away": "1078"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068353",
+        "pre_away": "1168"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068432",
+        "pre_away": "1247"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068549",
+        "pre_away": "1364"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068689",
+        "pre_away": "1504"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068773",
+        "pre_away": "1588"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068871",
+        "pre_away": "1686"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068969",
+        "pre_away": "1784"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442069078",
+        "pre_away": "1893"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069172",
+        "pre_away": "1987"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069312",
+        "pre_away": "2127"
+      }]
+    }, {
+      "trip_id": "28191097",
+      "trip_name": "10:25 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067720",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442067825",
+        "pre_away": "640"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442068046",
+        "pre_away": "861"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068179",
+        "pre_away": "994"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068299",
+        "pre_away": "1114"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068433",
+        "pre_away": "1248"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068572",
+        "pre_away": "1387"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442068651",
+        "pre_away": "1466"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068744",
+        "pre_away": "1559"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068835",
+        "pre_away": "1650"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068924",
+        "pre_away": "1739"
+      }]
+    }, {
+      "trip_id": "28191098",
+      "trip_name": "10:35 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068320",
+        "pre_away": "1135"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068425",
+        "pre_away": "1240"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068646",
+        "pre_away": "1461"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068779",
+        "pre_away": "1594"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442068899",
+        "pre_away": "1714"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069033",
+        "pre_away": "1848"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069172",
+        "pre_away": "1987"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442069251",
+        "pre_away": "2066"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442069340",
+        "sch_dep_dt": "1442069340",
+        "pre_dt": "1442069344",
+        "pre_away": "2159"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442069400",
+        "sch_dep_dt": "1442069400",
+        "pre_dt": "1442069435",
+        "pre_away": "2250"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442069520",
+        "sch_dep_dt": "1442069520",
+        "pre_dt": "1442069525",
+        "pre_away": "2340"
+      }]
+    }, {
+      "trip_id": "28191099",
+      "trip_name": "10:45 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442068920",
+        "pre_away": "1735"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069025",
+        "pre_away": "1840"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442069400",
+        "sch_dep_dt": "1442069400",
+        "pre_dt": "1442069246",
+        "pre_away": "2061"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069379",
+        "pre_away": "2194"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442069580",
+        "sch_dep_dt": "1442069580",
+        "pre_dt": "1442069499",
+        "pre_away": "2314"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069633",
+        "pre_away": "2448"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442069820",
+        "sch_dep_dt": "1442069820",
+        "pre_dt": "1442069772",
+        "pre_away": "2587"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442069880",
+        "sch_dep_dt": "1442069880",
+        "pre_dt": "1442069851",
+        "pre_away": "2666"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442069940",
+        "sch_dep_dt": "1442069940",
+        "pre_dt": "1442069944",
+        "pre_away": "2759"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442070000",
+        "sch_dep_dt": "1442070000",
+        "pre_dt": "1442070035",
+        "pre_away": "2850"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442070120",
+        "sch_dep_dt": "1442070120",
+        "pre_dt": "1442070125",
+        "pre_away": "2940"
+      }]
+    }, {
+      "trip_id": "28191100",
+      "trip_name": "10:55 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069520",
+        "pre_away": "2335"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442069820",
+        "sch_dep_dt": "1442069820",
+        "pre_dt": "1442069625",
+        "pre_away": "2440"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442070000",
+        "sch_dep_dt": "1442070000",
+        "pre_dt": "1442069846",
+        "pre_away": "2661"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442070060",
+        "sch_dep_dt": "1442070060",
+        "pre_dt": "1442069979",
+        "pre_away": "2794"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442070180",
+        "sch_dep_dt": "1442070180",
+        "pre_dt": "1442070099",
+        "pre_away": "2914"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442070300",
+        "sch_dep_dt": "1442070300",
+        "pre_dt": "1442070233",
+        "pre_away": "3048"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442070420",
+        "sch_dep_dt": "1442070420",
+        "pre_dt": "1442070372",
+        "pre_away": "3187"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442070480",
+        "sch_dep_dt": "1442070480",
+        "pre_dt": "1442070451",
+        "pre_away": "3266"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442070540",
+        "sch_dep_dt": "1442070540",
+        "pre_dt": "1442070544",
+        "pre_away": "3359"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442070600",
+        "sch_dep_dt": "1442070600",
+        "pre_dt": "1442070635",
+        "pre_away": "3450"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442070720",
+        "sch_dep_dt": "1442070720",
+        "pre_dt": "1442070724",
+        "pre_away": "3539"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28191134",
+      "trip_name": "9:45 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1249",
+        "vehicle_lat": "42.38587",
+        "vehicle_lon": "-71.07694",
+        "vehicle_bearing": "355",
+        "vehicle_timestamp": "1442067171"
+      },
+      "stop": [{
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "sch_arr_dt": "1442067060",
+        "sch_dep_dt": "1442067060",
+        "pre_dt": "1442067229",
+        "pre_away": "44"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "sch_arr_dt": "1442067120",
+        "sch_dep_dt": "1442067120",
+        "pre_dt": "1442067357",
+        "pre_away": "172"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067591",
+        "pre_away": "406"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067756",
+        "pre_away": "571"
+      }]
+    }, {
+      "trip_id": "28191130",
+      "trip_name": "9:55 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1252",
+        "vehicle_lat": "42.35533",
+        "vehicle_lon": "-71.06059",
+        "vehicle_bearing": "25",
+        "vehicle_timestamp": "1442067158"
+      },
+      "stop": [{
+        "stop_sequence": "110",
+        "stop_id": "70023",
+        "stop_name": "State Street - to Oak Grove",
+        "sch_arr_dt": "1442067240",
+        "sch_dep_dt": "1442067240",
+        "pre_dt": "1442067247",
+        "pre_away": "62"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70025",
+        "stop_name": "Haymarket - Orange Line Outbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067320",
+        "pre_away": "135"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70027",
+        "stop_name": "North Station - Orange Line Outbound",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067400",
+        "pre_away": "215"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70029",
+        "stop_name": "Community College - Outbound",
+        "sch_arr_dt": "1442067480",
+        "sch_dep_dt": "1442067480",
+        "pre_dt": "1442067532",
+        "pre_away": "347"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067659",
+        "pre_away": "474"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067766",
+        "pre_away": "581"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067894",
+        "pre_away": "709"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442068128",
+        "pre_away": "943"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442068293",
+        "pre_away": "1108"
+      }]
+    }, {
+      "trip_id": "28191126",
+      "trip_name": "10:05 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1201",
+        "vehicle_lat": "42.32318",
+        "vehicle_lon": "-71.09982",
+        "vehicle_bearing": "15",
+        "vehicle_timestamp": "1442067145"
+      },
+      "stop": [{
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067260",
+        "pre_away": "75"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067350",
+        "pre_away": "165"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067443",
+        "pre_away": "258"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067571",
+        "pre_away": "386"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067699",
+        "pre_away": "514"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067784",
+        "pre_away": "599"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067861",
+        "pre_away": "676"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70023",
+        "stop_name": "State Street - to Oak Grove",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067950",
+        "pre_away": "765"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70025",
+        "stop_name": "Haymarket - Orange Line Outbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442068023",
+        "pre_away": "838"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70027",
+        "stop_name": "North Station - Orange Line Outbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442068103",
+        "pre_away": "918"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70029",
+        "stop_name": "Community College - Outbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068235",
+        "pre_away": "1050"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442068362",
+        "pre_away": "1177"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068469",
+        "pre_away": "1284"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068597",
+        "pre_away": "1412"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068830",
+        "pre_away": "1645"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068995",
+        "pre_away": "1810"
+      }]
+    }, {
+      "trip_id": "28191122",
+      "trip_name": "10:15 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442067300",
+        "sch_dep_dt": "1442067300",
+        "pre_dt": "1442067300",
+        "pre_away": "115"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442067420",
+        "sch_dep_dt": "1442067420",
+        "pre_dt": "1442067392",
+        "pre_away": "207"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067487",
+        "pre_away": "302"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067610",
+        "pre_away": "425"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067725",
+        "pre_away": "540"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067815",
+        "pre_away": "630"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442067908",
+        "pre_away": "723"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068036",
+        "pre_away": "851"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068164",
+        "pre_away": "979"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068249",
+        "pre_away": "1064"
+      }]
+    }, {
+      "trip_id": "28191118",
+      "trip_name": "10:25 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067900",
+        "pre_away": "715"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442067992",
+        "pre_away": "807"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068087",
+        "pre_away": "902"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068192",
+        "pre_away": "1007"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068307",
+        "pre_away": "1122"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068397",
+        "pre_away": "1212"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068490",
+        "pre_away": "1305"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068618",
+        "pre_away": "1433"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068746",
+        "pre_away": "1561"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068831",
+        "pre_away": "1646"
+      }]
+    }, {
+      "trip_id": "28191113",
+      "trip_name": "10:35 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068500",
+        "pre_away": "1315"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068592",
+        "pre_away": "1407"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068687",
+        "pre_away": "1502"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068792",
+        "pre_away": "1607"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442068907",
+        "pre_away": "1722"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442068997",
+        "pre_away": "1812"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069090",
+        "pre_away": "1905"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442069340",
+        "sch_dep_dt": "1442069340",
+        "pre_dt": "1442069218",
+        "pre_away": "2033"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069346",
+        "pre_away": "2161"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442069520",
+        "sch_dep_dt": "1442069520",
+        "pre_dt": "1442069431",
+        "pre_away": "2246"
+      }]
+    }, {
+      "trip_id": "28191108",
+      "trip_name": "10:45 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069100",
+        "pre_away": "1915"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069192",
+        "pre_away": "2007"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442069340",
+        "sch_dep_dt": "1442069340",
+        "pre_dt": "1442069287",
+        "pre_away": "2102"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069392",
+        "pre_away": "2207"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442069580",
+        "sch_dep_dt": "1442069580",
+        "pre_dt": "1442069507",
+        "pre_away": "2322"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069597",
+        "pre_away": "2412"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442069820",
+        "sch_dep_dt": "1442069820",
+        "pre_dt": "1442069690",
+        "pre_away": "2505"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442069940",
+        "sch_dep_dt": "1442069940",
+        "pre_dt": "1442069818",
+        "pre_away": "2633"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442070060",
+        "sch_dep_dt": "1442070060",
+        "pre_dt": "1442069946",
+        "pre_away": "2761"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442070120",
+        "sch_dep_dt": "1442070120",
+        "pre_dt": "1442070031",
+        "pre_away": "2846"
+      }]
+    }, {
+      "trip_id": "28191137",
+      "trip_name": "10:55 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069700",
+        "pre_away": "2515"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442069820",
+        "sch_dep_dt": "1442069820",
+        "pre_dt": "1442069792",
+        "pre_away": "2607"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442069940",
+        "sch_dep_dt": "1442069940",
+        "pre_dt": "1442069887",
+        "pre_away": "2702"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442070060",
+        "sch_dep_dt": "1442070060",
+        "pre_dt": "1442069992",
+        "pre_away": "2807"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442070180",
+        "sch_dep_dt": "1442070180",
+        "pre_dt": "1442070107",
+        "pre_away": "2922"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442070300",
+        "sch_dep_dt": "1442070300",
+        "pre_dt": "1442070197",
+        "pre_away": "3012"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442070420",
+        "sch_dep_dt": "1442070420",
+        "pre_dt": "1442070290",
+        "pre_away": "3105"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442070540",
+        "sch_dep_dt": "1442070540",
+        "pre_dt": "1442070418",
+        "pre_away": "3233"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442070660",
+        "sch_dep_dt": "1442070660",
+        "pre_dt": "1442070546",
+        "pre_away": "3361"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442070720",
+        "sch_dep_dt": "1442070720",
+        "pre_dt": "1442070631",
+        "pre_away": "3446"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }]
+}

--- a/fixtures/bad-sequencing/realtime.mbta.com/predictions-red.fixture
+++ b/fixtures/bad-sequencing/realtime.mbta.com/predictions-red.fixture
@@ -1,0 +1,1116 @@
+GET /developer/api/v2/predictionsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 14:12:51 GMT
+connection: close
+content-length: 22796
+
+{
+  "route_id": "Red",
+  "route_name": "Red Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "",
+    "direction_name": "",
+    "trip": [{
+      "trip_id": "9838554A",
+      "trip_name": "Quincy Center to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1863",
+        "vehicle_lat": "42.25494",
+        "vehicle_lon": "-71.00804",
+        "vehicle_bearing": "315",
+        "vehicle_timestamp": "1442066655"
+      },
+      "stop": [{
+        "stop_sequence": "",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "pre_dt": "1442068945",
+        "pre_away": "1776"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "pre_dt": "1442068826",
+        "pre_away": "1657"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "pre_dt": "1442068629",
+        "pre_away": "1460"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "pre_dt": "1442068436",
+        "pre_away": "1267"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "pre_dt": "1442068291",
+        "pre_away": "1122"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "pre_dt": "1442068139",
+        "pre_away": "970"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "pre_dt": "1442068015",
+        "pre_away": "846"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "pre_dt": "1442067916",
+        "pre_away": "747"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "pre_dt": "1442067836",
+        "pre_away": "667"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "pre_dt": "1442067682",
+        "pre_away": "513"
+      }, {
+        "stop_sequence": "",
+        "stop_id": "70084",
+        "stop_name": "Andrew - Inbound",
+        "pre_dt": "1442067549",
+        "pre_away": "380"
+      }]
+    }]
+  }, {
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28194307",
+      "trip_name": "9:42 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1512",
+        "vehicle_lat": "42.3168",
+        "vehicle_lon": "-71.05238",
+        "vehicle_bearing": "170",
+        "vehicle_timestamp": "1442067140"
+      },
+      "stop": [{
+        "stop_sequence": "140",
+        "stop_id": "70087",
+        "stop_name": "Savin Hill - Outbound",
+        "sch_arr_dt": "1442067000",
+        "sch_dep_dt": "1442067000",
+        "pre_dt": "1442067206",
+        "pre_away": "37"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70089",
+        "stop_name": "Fields Corner - Outbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067381",
+        "pre_away": "212"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70091",
+        "stop_name": "Shawmut - Outbound",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067519",
+        "pre_away": "350"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "sch_arr_dt": "1442067480",
+        "sch_dep_dt": "1442067480",
+        "pre_dt": "1442067665",
+        "pre_away": "496"
+      }]
+    }, {
+      "trip_id": "28194418",
+      "trip_name": "9:49 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1619",
+        "vehicle_lat": "42.35252",
+        "vehicle_lon": "-71.05533",
+        "vehicle_bearing": "130",
+        "vehicle_timestamp": "1442067158"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442067060",
+        "sch_dep_dt": "1442067060",
+        "pre_dt": "1442067303",
+        "pre_away": "134"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442067180",
+        "sch_dep_dt": "1442067180",
+        "pre_dt": "1442067435",
+        "pre_away": "266"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068934",
+        "pre_away": "1765"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442069200",
+        "pre_away": "2031"
+      }]
+    }, {
+      "trip_id": "28194315",
+      "trip_name": "10:10 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1606",
+        "vehicle_lat": "42.36553",
+        "vehicle_lon": "-71.10403",
+        "vehicle_bearing": "130",
+        "vehicle_timestamp": "1442067157"
+      },
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067315",
+        "pre_away": "146"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70073",
+        "stop_name": "Charles/MGH - Inbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067462",
+        "pre_away": "293"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442067585",
+        "pre_away": "416"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442067701",
+        "pre_away": "532"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442067795",
+        "pre_away": "626"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442067940",
+        "pre_away": "771"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068072",
+        "pre_away": "903"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70087",
+        "stop_name": "Savin Hill - Outbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068397",
+        "pre_away": "1228"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70089",
+        "stop_name": "Fields Corner - Outbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442068572",
+        "pre_away": "1403"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70091",
+        "stop_name": "Shawmut - Outbound",
+        "sch_arr_dt": "1442069160",
+        "sch_dep_dt": "1442069160",
+        "pre_dt": "1442068710",
+        "pre_away": "1541"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442068856",
+        "pre_away": "1687"
+      }]
+    }, {
+      "trip_id": "28194420",
+      "trip_name": "10:17 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1860",
+        "vehicle_lat": "42.39454",
+        "vehicle_lon": "-71.11951",
+        "vehicle_bearing": "170",
+        "vehicle_timestamp": "1442067137"
+      },
+      "stop": [{
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442067660",
+        "sch_dep_dt": "1442067660",
+        "pre_dt": "1442067181",
+        "pre_away": "12"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067346",
+        "pre_away": "177"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442068020",
+        "sch_dep_dt": "1442068020",
+        "pre_dt": "1442067560",
+        "pre_away": "391"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442067718",
+        "pre_away": "549"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70073",
+        "stop_name": "Charles/MGH - Inbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442067865",
+        "pre_away": "696"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442067988",
+        "pre_away": "819"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "sch_arr_dt": "1442068560",
+        "sch_dep_dt": "1442068560",
+        "pre_dt": "1442068104",
+        "pre_away": "935"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442068198",
+        "pre_away": "1029"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442068343",
+        "pre_away": "1174"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068475",
+        "pre_away": "1306"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "sch_arr_dt": "1442070180",
+        "sch_dep_dt": "1442070180",
+        "pre_dt": "1442069974",
+        "pre_away": "2805"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442070420",
+        "sch_dep_dt": "1442070420",
+        "pre_dt": "1442070240",
+        "pre_away": "3071"
+      }]
+    }, {
+      "trip_id": "28194308",
+      "trip_name": "10:24 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067900",
+        "pre_away": "731"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442067985",
+        "pre_away": "816"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068110",
+        "pre_away": "941"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068277",
+        "pre_away": "1108"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068491",
+        "pre_away": "1322"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068649",
+        "pre_away": "1480"
+      }]
+    }, {
+      "trip_id": "28194363",
+      "trip_name": "10:38 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442068680",
+        "sch_dep_dt": "1442068680",
+        "pre_dt": "1442069100",
+        "pre_away": "1931"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "sch_arr_dt": "1442068800",
+        "sch_dep_dt": "1442068800",
+        "pre_dt": "1442069210",
+        "pre_away": "2041"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442069332",
+        "pre_away": "2163"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442069497",
+        "pre_away": "2328"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442069711",
+        "pre_away": "2542"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069869",
+        "pre_away": "2700"
+      }]
+    }, {
+      "trip_id": "9838554C",
+      "trip_name": "Quincy Center to Braintree",
+      "trip_headsign": "Braintree",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "pre_dt": "1442069998",
+        "pre_away": "2829"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "pre_dt": "1442070108",
+        "pre_away": "2939"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "pre_dt": "1442070230",
+        "pre_away": "3061"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "pre_dt": "1442070395",
+        "pre_away": "3226"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "pre_dt": "1442070609",
+        "pre_away": "3440"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "pre_dt": "1442070767",
+        "pre_away": "3598"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28194233",
+      "trip_name": "9:41 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1801",
+        "vehicle_lat": "42.39676",
+        "vehicle_lon": "-71.12241",
+        "vehicle_bearing": "285",
+        "vehicle_timestamp": "1442067156"
+      },
+      "stop": [{
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067313",
+        "pre_away": "144"
+      }]
+    }, {
+      "trip_id": "28194401",
+      "trip_name": "9:55 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1717",
+        "vehicle_lat": "42.35107",
+        "vehicle_lon": "-71.05232",
+        "vehicle_bearing": "355",
+        "vehicle_timestamp": "1442067129"
+      },
+      "stop": [{
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "sch_arr_dt": "1442067120",
+        "sch_dep_dt": "1442067120",
+        "pre_dt": "1442067169",
+        "pre_away": "0"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "sch_arr_dt": "1442067240",
+        "sch_dep_dt": "1442067240",
+        "pre_dt": "1442067249",
+        "pre_away": "80"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067360",
+        "pre_away": "191"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "sch_arr_dt": "1442067480",
+        "sch_dep_dt": "1442067480",
+        "pre_dt": "1442067484",
+        "pre_away": "315"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "sch_arr_dt": "1442067600",
+        "sch_dep_dt": "1442067600",
+        "pre_dt": "1442067636",
+        "pre_away": "467"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067781",
+        "pre_away": "612"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442067900",
+        "sch_dep_dt": "1442067900",
+        "pre_dt": "1442067974",
+        "pre_away": "805"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442068157",
+        "pre_away": "988"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068276",
+        "pre_away": "1107"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068433",
+        "pre_away": "1264"
+      }]
+    }, {
+      "trip_id": "28194329",
+      "trip_name": "10:05 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1824",
+        "vehicle_lat": "42.23337",
+        "vehicle_lon": "-71.00682",
+        "vehicle_bearing": "15",
+        "vehicle_timestamp": "1442067126"
+      },
+      "stop": [{
+        "stop_sequence": "110",
+        "stop_id": "70084",
+        "stop_name": "Andrew - Inbound",
+        "sch_arr_dt": "1442068140",
+        "sch_dep_dt": "1442068140",
+        "pre_dt": "1442068208",
+        "pre_away": "1039"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "sch_arr_dt": "1442068260",
+        "sch_dep_dt": "1442068260",
+        "pre_dt": "1442068343",
+        "pre_away": "1174"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "sch_arr_dt": "1442068380",
+        "sch_dep_dt": "1442068380",
+        "pre_dt": "1442068495",
+        "pre_away": "1326"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "sch_arr_dt": "1442068500",
+        "sch_dep_dt": "1442068500",
+        "pre_dt": "1442068575",
+        "pre_away": "1406"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068686",
+        "pre_away": "1517"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068810",
+        "pre_away": "1641"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068962",
+        "pre_away": "1793"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "sch_arr_dt": "1442068980",
+        "sch_dep_dt": "1442068980",
+        "pre_dt": "1442069107",
+        "pre_away": "1938"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442069160",
+        "sch_dep_dt": "1442069160",
+        "pre_dt": "1442069300",
+        "pre_away": "2131"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442069340",
+        "sch_dep_dt": "1442069340",
+        "pre_dt": "1442069483",
+        "pre_away": "2314"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442069520",
+        "sch_dep_dt": "1442069520",
+        "pre_dt": "1442069602",
+        "pre_away": "2433"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442069700",
+        "sch_dep_dt": "1442069700",
+        "pre_dt": "1442069759",
+        "pre_away": "2590"
+      }]
+    }, {
+      "trip_id": "28194360",
+      "trip_name": "10:09 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1812",
+        "vehicle_lat": "42.30029",
+        "vehicle_lon": "-71.05826",
+        "vehicle_bearing": "85",
+        "vehicle_timestamp": "1442067142"
+      },
+      "stop": [{
+        "stop_sequence": "80",
+        "stop_id": "70088",
+        "stop_name": "Savin Hill - Inbound",
+        "sch_arr_dt": "1442067360",
+        "sch_dep_dt": "1442067360",
+        "pre_dt": "1442067233",
+        "pre_away": "64"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70084",
+        "stop_name": "Andrew - Inbound",
+        "sch_arr_dt": "1442067720",
+        "sch_dep_dt": "1442067720",
+        "pre_dt": "1442067556",
+        "pre_away": "387"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "sch_arr_dt": "1442067840",
+        "sch_dep_dt": "1442067840",
+        "pre_dt": "1442067691",
+        "pre_away": "522"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "sch_arr_dt": "1442067960",
+        "sch_dep_dt": "1442067960",
+        "pre_dt": "1442067843",
+        "pre_away": "674"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "sch_arr_dt": "1442068080",
+        "sch_dep_dt": "1442068080",
+        "pre_dt": "1442067923",
+        "pre_away": "754"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "sch_arr_dt": "1442068200",
+        "sch_dep_dt": "1442068200",
+        "pre_dt": "1442068034",
+        "pre_away": "865"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "sch_arr_dt": "1442068320",
+        "sch_dep_dt": "1442068320",
+        "pre_dt": "1442068158",
+        "pre_away": "989"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "sch_arr_dt": "1442068440",
+        "sch_dep_dt": "1442068440",
+        "pre_dt": "1442068310",
+        "pre_away": "1141"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "sch_arr_dt": "1442068560",
+        "sch_dep_dt": "1442068560",
+        "pre_dt": "1442068455",
+        "pre_away": "1286"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068648",
+        "pre_away": "1479"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442068920",
+        "sch_dep_dt": "1442068920",
+        "pre_dt": "1442068831",
+        "pre_away": "1662"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442069100",
+        "sch_dep_dt": "1442069100",
+        "pre_dt": "1442068950",
+        "pre_away": "1781"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442069280",
+        "sch_dep_dt": "1442069280",
+        "pre_dt": "1442069107",
+        "pre_away": "1938"
+      }]
+    }, {
+      "trip_id": "28194184",
+      "trip_name": "10:19 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442067540",
+        "sch_dep_dt": "1442067540",
+        "pre_dt": "1442067300",
+        "pre_away": "131"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70104",
+        "stop_name": "Quincy Adams - Inbound",
+        "sch_arr_dt": "1442067780",
+        "sch_dep_dt": "1442067780",
+        "pre_dt": "1442067560",
+        "pre_away": "391"
+      }]
+    }, {
+      "trip_id": "9838550C",
+      "trip_name": "Ashmont to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70094",
+        "stop_name": "Ashmont - Inbound",
+        "pre_dt": "1442067360",
+        "pre_away": "191"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70092",
+        "stop_name": "Shawmut - Inbound",
+        "pre_dt": "1442067432",
+        "pre_away": "263"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70090",
+        "stop_name": "Fields Corner - Inbound",
+        "pre_dt": "1442067541",
+        "pre_away": "372"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70088",
+        "stop_name": "Savin Hill - Inbound",
+        "pre_dt": "1442067709",
+        "pre_away": "540"
+      }]
+    }, {
+      "trip_id": "9838550A",
+      "trip_name": "Ashmont to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1725",
+        "vehicle_lat": "42.36203",
+        "vehicle_lon": "-71.08088",
+        "vehicle_bearing": "275",
+        "vehicle_timestamp": "1442067132"
+      },
+      "stop": [{
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "pre_dt": "1442067183",
+        "pre_away": "14"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "pre_dt": "1442067328",
+        "pre_away": "159"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "pre_dt": "1442067521",
+        "pre_away": "352"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "pre_dt": "1442067704",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "pre_dt": "1442067823",
+        "pre_away": "654"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "pre_dt": "1442067980",
+        "pre_away": "811"
+      }]
+    }, {
+      "trip_id": "28194479",
+      "trip_name": "10:37 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70094",
+        "stop_name": "Ashmont - Inbound",
+        "sch_arr_dt": "1442068620",
+        "sch_dep_dt": "1442068620",
+        "pre_dt": "1442068560",
+        "pre_away": "1391"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70092",
+        "stop_name": "Shawmut - Inbound",
+        "sch_arr_dt": "1442068740",
+        "sch_dep_dt": "1442068740",
+        "pre_dt": "1442068632",
+        "pre_away": "1463"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70090",
+        "stop_name": "Fields Corner - Inbound",
+        "sch_arr_dt": "1442068860",
+        "sch_dep_dt": "1442068860",
+        "pre_dt": "1442068741",
+        "pre_away": "1572"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70088",
+        "stop_name": "Savin Hill - Inbound",
+        "sch_arr_dt": "1442069040",
+        "sch_dep_dt": "1442069040",
+        "pre_dt": "1442068909",
+        "pre_away": "1740"
+      }]
+    }, {
+      "trip_id": "28194221",
+      "trip_name": "10:47 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442069220",
+        "sch_dep_dt": "1442069220",
+        "pre_dt": "1442069368",
+        "pre_away": "2199"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70104",
+        "stop_name": "Quincy Adams - Inbound",
+        "sch_arr_dt": "1442069460",
+        "sch_dep_dt": "1442069460",
+        "pre_dt": "1442069628",
+        "pre_away": "2459"
+      }]
+    }, {
+      "trip_id": "28194289",
+      "trip_name": "11:05 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70094",
+        "stop_name": "Ashmont - Inbound",
+        "sch_arr_dt": "1442070300",
+        "sch_dep_dt": "1442070300",
+        "pre_dt": "1442070360",
+        "pre_away": "3191"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70092",
+        "stop_name": "Shawmut - Inbound",
+        "sch_arr_dt": "1442070420",
+        "sch_dep_dt": "1442070420",
+        "pre_dt": "1442070432",
+        "pre_away": "3263"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70090",
+        "stop_name": "Fields Corner - Inbound",
+        "sch_arr_dt": "1442070540",
+        "sch_dep_dt": "1442070540",
+        "pre_dt": "1442070541",
+        "pre_away": "3372"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70088",
+        "stop_name": "Savin Hill - Inbound",
+        "sch_arr_dt": "1442070720",
+        "sch_dep_dt": "1442070720",
+        "pre_dt": "1442070709",
+        "pre_away": "3540"
+      }]
+    }, {
+      "trip_id": "28194295",
+      "trip_name": "11:15 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442070900",
+        "sch_dep_dt": "1442070900",
+        "pre_dt": "1442070900",
+        "pre_away": "3731"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70104",
+        "stop_name": "Quincy Adams - Inbound",
+        "sch_arr_dt": "1442071140",
+        "sch_dep_dt": "1442071140",
+        "pre_dt": "1442071160",
+        "pre_away": "3991"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }, {
+    "alert_id": 90418,
+    "header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "effect_name": "Shuttle"
+  }]
+}

--- a/fixtures/last-train/realtime.mbta.com/alerts-blue.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-blue.fixture
@@ -1,0 +1,69 @@
+GET /developer/api/v2/alertsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:03 GMT
+connection: close
+content-length: 1980
+
+{
+  "alerts": [{
+    "alert_id": 93195,
+    "effect_name": "Service Change",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/riding_the_t/default.asp?id=26899",
+    "description_text": "As part of the project to make Government Center Station fully accessible, all passengers will board and exit on the westbound platform at Bowdoin Station from start to end of service during the following weekends:\r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015\r\n\r\nThe eastbound platform at Bowdoin will be available the following Mondays. The Government Center shuttle bus between State, Government Center, Bowdoin, and Haymarket is unaffected by this service change.\r\n\r\nAffected stops:\r\nBowdoin",
+    "severity": "Minor",
+    "created_dt": "1441904256",
+    "last_modified_dt": "1441904256",
+    "service_effect_text": "Blue Line notice",
+    "timeframe_text": "starting tomorrow",
+    "alert_lifecycle": "Upcoming",
+    "recurrence_text": "weekends",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442125800"
+    }, {
+      "effect_start": "1442133000",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442651400",
+      "effect_end": "1442730600"
+    }, {
+      "effect_start": "1442737800",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1443256200",
+      "effect_end": "1443335400"
+    }, {
+      "effect_start": "1443342600",
+      "effect_end": "1443421800"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Blue",
+        "route_name": "Blue Line",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Blue",
+  "route_name": "Blue Line"
+}

--- a/fixtures/last-train/realtime.mbta.com/alerts-green-b.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-green-b.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-B&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:14 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-B","route_name":"Green Line B"}

--- a/fixtures/last-train/realtime.mbta.com/alerts-green-c.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-green-c.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-C&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:14 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-C","route_name":"Green Line C"}

--- a/fixtures/last-train/realtime.mbta.com/alerts-green-d.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-green-d.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-D&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:14 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-D","route_name":"Green Line D"}

--- a/fixtures/last-train/realtime.mbta.com/alerts-green-e.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-green-e.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-E&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:14 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-E","route_name":"Green Line E"}

--- a/fixtures/last-train/realtime.mbta.com/alerts-orange.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-orange.fixture
@@ -1,0 +1,289 @@
+GET /developer/api/v2/alertsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:09 GMT
+connection: close
+content-length: 9004
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90254,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Oak Grove and Sullivan Stations on September 13-17, 20-24, and 27-30 as well as October 1, 4-8, 11-15, 19-22, and 25-29 from approximately 8:45 p.m. through the end of service",
+    "short_header_text": "Buses replacing Orange Ln between Oak Grove & Sullivan on Sep 13-17, 20-24, & 27-30 & Oct 1, 4-8, 11-15, 19-22, & 25-29 from about 8:45pm un",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing work as part of the Winter Resiliency Improvement Program, alternate shuttle buses will replace Orange Line trains in both directions from Sullivan to Oak Grove Stations beginning at approximately 8:45 p.m. through the end of service on the following dates: \r\n\r\n- Sunday, September 13, 2015, through Thursday, September 17, 2015. \r\n- Sunday, September 20, 2015, through Thursday, September 24, 2015. \r\n- Sunday, September 27, 2015, through Thursday, October 1, 2015.\r\n- Sunday, October 4, 2015, through Thursday, October 8, 2015.\r\n- Sunday, October 11, 2015, through Thursday, October 15, 2015\r\n- Monday, October 19, 2015, through Thursday, October 22, 2015\r\n- Sunday, October 25, 2015, through Thursday, October 29, 2015.\r\n\r\nRegular Orange Line trains will resume at the start of service the next day. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nOak Grove\r\nMalden Center\r\nWellington\r\nAssembly\r\nSullivan Square",
+    "severity": "Severe",
+    "created_dt": "1439849389",
+    "last_modified_dt": "1441969989",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "starting Sunday",
+    "alert_lifecycle": "Upcoming",
+    "recurrence_text": "Sunday-Thursday",
+    "effect_periods": [{
+      "effect_start": "1442191500",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442277900",
+      "effect_end": "1442298600"
+    }, {
+      "effect_start": "1442364300",
+      "effect_end": "1442385000"
+    }, {
+      "effect_start": "1442450700",
+      "effect_end": "1442471400"
+    }, {
+      "effect_start": "1442537100",
+      "effect_end": "1442557800"
+    }, {
+      "effect_start": "1442796300",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1442882700",
+      "effect_end": "1442903400"
+    }, {
+      "effect_start": "1442969100",
+      "effect_end": "1442989800"
+    }, {
+      "effect_start": "1443055500",
+      "effect_end": "1443076200"
+    }, {
+      "effect_start": "1443141900",
+      "effect_end": "1443162600"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 92997,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "short_header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Orange Line trains between Forest Hills and Ruggles Stations in both directions from start to end of service beginning Saturday, October 17, through Sunday, October 18. Regular Red Line train service will resume at the start of service on Monday, October 19. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops: \r\nRuggles\r\nRoxbury Crossing\r\nJackson Square\r\nStony Brook\r\nGreen Street\r\nForest Hills",
+    "severity": "Severe",
+    "created_dt": "1441809730",
+    "last_modified_dt": "1441809730",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "October 17-18",
+    "alert_lifecycle": "Upcoming",
+    "effect_periods": [{
+      "effect_start": "1445070600",
+      "effect_end": "1445236200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Orange",
+  "route_name": "Orange Line"
+}

--- a/fixtures/last-train/realtime.mbta.com/alerts-red.fixture
+++ b/fixtures/last-train/realtime.mbta.com/alerts-red.fixture
@@ -1,0 +1,167 @@
+GET /developer/api/v2/alertsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:06 GMT
+connection: close
+content-length: 5240
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90418,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Red Line trains between JFK/UMass and Quincy Center Stations in both directions from start to end of service during the following weekends: \r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015.\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015.\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015. \r\n\r\nRegular Red Line train service will resume at the start of service on Mondays. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nJFK/UMass\r\nNorth Quincy\r\nWollaston\r\nQuincy Center",
+    "severity": "Severe",
+    "created_dt": "1439993541",
+    "last_modified_dt": "1441965786",
+    "service_effect_text": "Red Line shuttle",
+    "timeframe_text": "this weekend",
+    "alert_lifecycle": "Upcoming",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442212200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70086",
+        "stop_name": "JFK/UMASS Ashmont - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70095",
+        "stop_name": "JFK/UMASS Braintree - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70096",
+        "stop_name": "JFK/UMASS Braintree - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70098",
+        "stop_name": "North Quincy - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70100",
+        "stop_name": "Wollaston - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70102",
+        "stop_name": "Quincy Center - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Red",
+  "route_name": "Red Line"
+}

--- a/fixtures/last-train/realtime.mbta.com/predictions-blue.fixture
+++ b/fixtures/last-train/realtime.mbta.com/predictions-blue.fixture
@@ -1,0 +1,100 @@
+GET /developer/api/v2/predictionsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:13:59 GMT
+connection: close
+content-length: 1535
+
+{
+  "route_id": "Blue",
+  "route_name": "Blue Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "1",
+    "direction_name": "Eastbound",
+    "trip": [{
+      "trip_id": "98A6B76E",
+      "trip_name": "Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "pre_dt": "1442038544",
+        "pre_away": "110"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "pre_dt": "1442038644",
+        "pre_away": "210"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "pre_dt": "1442038723",
+        "pre_away": "289"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "pre_dt": "1442038872",
+        "pre_away": "438"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "pre_dt": "1442039012",
+        "pre_away": "578"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "pre_dt": "1442039115",
+        "pre_away": "681"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "pre_dt": "1442039298",
+        "pre_away": "864"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "pre_dt": "1442039414",
+        "pre_away": "980"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "pre_dt": "1442039503",
+        "pre_away": "1069"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "pre_dt": "1442039641",
+        "pre_away": "1207"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "pre_dt": "1442039746",
+        "pre_away": "1312"
+      }]
+    }]
+  }],
+  "alert_headers": []
+}

--- a/fixtures/last-train/realtime.mbta.com/predictions-orange.fixture
+++ b/fixtures/last-train/realtime.mbta.com/predictions-orange.fixture
@@ -1,0 +1,365 @@
+GET /developer/api/v2/predictionsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:09 GMT
+connection: close
+content-length: 7355
+
+{
+  "route_id": "Orange",
+  "route_name": "Orange Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28190958",
+      "trip_name": "Oak Grove to Forest Hills",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1223",
+        "vehicle_lat": "42.35538",
+        "vehicle_lon": "-71.06065",
+        "vehicle_bearing": "205",
+        "vehicle_timestamp": "1442038262"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "pre_dt": "1442038444",
+        "pre_away": "4"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "pre_dt": "1442038514",
+        "pre_away": "65"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "pre_dt": "1442038627",
+        "pre_away": "178"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "pre_dt": "1442038774",
+        "pre_away": "325"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "pre_dt": "1442038860",
+        "pre_away": "411"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "pre_dt": "1442038963",
+        "pre_away": "514"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "pre_dt": "1442039062",
+        "pre_away": "613"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "pre_dt": "1442039161",
+        "pre_away": "712"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "pre_dt": "1442039253",
+        "pre_away": "804"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "pre_dt": "1442039400",
+        "pre_away": "951"
+      }]
+    }, {
+      "trip_id": "28191232",
+      "trip_name": "1:49 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1223",
+        "vehicle_lat": "42.35538",
+        "vehicle_lon": "-71.06065",
+        "vehicle_bearing": "205",
+        "vehicle_timestamp": "1442038262"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442124360",
+        "sch_dep_dt": "1442124360",
+        "pre_dt": "1442038444",
+        "pre_away": "4"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "sch_arr_dt": "1442124420",
+        "sch_dep_dt": "1442124420",
+        "pre_dt": "1442038514",
+        "pre_away": "65"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "sch_arr_dt": "1442124540",
+        "sch_dep_dt": "1442124540",
+        "pre_dt": "1442038627",
+        "pre_away": "178"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "sch_arr_dt": "1442124660",
+        "sch_dep_dt": "1442124660",
+        "pre_dt": "1442038774",
+        "pre_away": "325"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "sch_arr_dt": "1442124780",
+        "sch_dep_dt": "1442124780",
+        "pre_dt": "1442038860",
+        "pre_away": "411"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442124840",
+        "sch_dep_dt": "1442124840",
+        "pre_dt": "1442038963",
+        "pre_away": "514"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442124900",
+        "sch_dep_dt": "1442124900",
+        "pre_dt": "1442039062",
+        "pre_away": "613"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442124960",
+        "sch_dep_dt": "1442124960",
+        "pre_dt": "1442039161",
+        "pre_away": "712"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442125080",
+        "sch_dep_dt": "1442125080",
+        "pre_dt": "1442039253",
+        "pre_away": "804"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442125200",
+        "sch_dep_dt": "1442125200",
+        "pre_dt": "1442039400",
+        "pre_away": "951"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28190956",
+      "trip_name": "Forest Hills to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1315",
+        "vehicle_lat": "42.35235",
+        "vehicle_lon": "-71.06259",
+        "vehicle_bearing": "5",
+        "vehicle_timestamp": "1442038374"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove",
+        "pre_dt": "1442038452",
+        "pre_away": "3"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70023",
+        "stop_name": "State Street - to Oak Grove",
+        "pre_dt": "1442038554",
+        "pre_away": "105"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70025",
+        "stop_name": "Haymarket - Orange Line Outbound",
+        "pre_dt": "1442038630",
+        "pre_away": "181"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70027",
+        "stop_name": "North Station - Orange Line Outbound",
+        "pre_dt": "1442038709",
+        "pre_away": "260"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70029",
+        "stop_name": "Community College - Outbound",
+        "pre_dt": "1442038846",
+        "pre_away": "397"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound",
+        "pre_dt": "1442038968",
+        "pre_away": "519"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "pre_dt": "1442039096",
+        "pre_away": "647"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "pre_dt": "1442039234",
+        "pre_away": "785"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "pre_dt": "1442039451",
+        "pre_away": "1002"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "pre_dt": "1442039610",
+        "pre_away": "1161"
+      }]
+    }, {
+      "trip_id": "28191236",
+      "trip_name": "1:45 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1315",
+        "vehicle_lat": "42.35235",
+        "vehicle_lon": "-71.06259",
+        "vehicle_bearing": "5",
+        "vehicle_timestamp": "1442038374"
+      },
+      "stop": [{
+        "stop_sequence": "100",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove",
+        "sch_arr_dt": "1442124180",
+        "sch_dep_dt": "1442124180",
+        "pre_dt": "1442038452",
+        "pre_away": "3"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70023",
+        "stop_name": "State Street - to Oak Grove",
+        "sch_arr_dt": "1442124240",
+        "sch_dep_dt": "1442124240",
+        "pre_dt": "1442038554",
+        "pre_away": "105"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70025",
+        "stop_name": "Haymarket - Orange Line Outbound",
+        "sch_arr_dt": "1442124300",
+        "sch_dep_dt": "1442124300",
+        "pre_dt": "1442038630",
+        "pre_away": "181"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70027",
+        "stop_name": "North Station - Orange Line Outbound",
+        "sch_arr_dt": "1442124360",
+        "sch_dep_dt": "1442124360",
+        "pre_dt": "1442038709",
+        "pre_away": "260"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70029",
+        "stop_name": "Community College - Outbound",
+        "sch_arr_dt": "1442124480",
+        "sch_dep_dt": "1442124480",
+        "pre_dt": "1442038846",
+        "pre_away": "397"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound",
+        "sch_arr_dt": "1442124600",
+        "sch_dep_dt": "1442124600",
+        "pre_dt": "1442038968",
+        "pre_away": "519"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "sch_arr_dt": "1442124660",
+        "sch_dep_dt": "1442124660",
+        "pre_dt": "1442039096",
+        "pre_away": "647"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "sch_arr_dt": "1442124720",
+        "sch_dep_dt": "1442124720",
+        "pre_dt": "1442039234",
+        "pre_away": "785"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "sch_arr_dt": "1442124900",
+        "sch_dep_dt": "1442124900",
+        "pre_dt": "1442039451",
+        "pre_away": "1002"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442125020",
+        "sch_dep_dt": "1442125020",
+        "pre_dt": "1442039610",
+        "pre_away": "1161"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }]
+}

--- a/fixtures/last-train/realtime.mbta.com/predictions-red.fixture
+++ b/fixtures/last-train/realtime.mbta.com/predictions-red.fixture
@@ -1,0 +1,615 @@
+GET /developer/api/v2/predictionsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 06:14:06 GMT
+connection: close
+content-length: 12185
+
+{
+  "route_id": "Red",
+  "route_name": "Red Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28194146",
+      "trip_name": "Alewife to Ashmont",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1615",
+        "vehicle_lat": "42.2932",
+        "vehicle_lon": "-71.06586",
+        "vehicle_bearing": "160",
+        "vehicle_timestamp": "1442038380"
+      },
+      "stop": [{
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "pre_dt": "1442038532",
+        "pre_away": "98"
+      }]
+    }, {
+      "trip_id": "28194157",
+      "trip_name": "Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1879",
+        "vehicle_lat": "42.23131",
+        "vehicle_lon": "-71.00711",
+        "vehicle_bearing": "180",
+        "vehicle_timestamp": "1442038393"
+      },
+      "stop": [{
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "pre_dt": "1442038619",
+        "pre_away": "185"
+      }]
+    }, {
+      "trip_id": "28194160",
+      "trip_name": "Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1745",
+        "vehicle_lat": "42.3185",
+        "vehicle_lon": "-71.05212",
+        "vehicle_bearing": "170",
+        "vehicle_timestamp": "1442038416"
+      },
+      "stop": [{
+        "stop_sequence": "180",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound",
+        "pre_dt": "1442038835",
+        "pre_away": "401"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound",
+        "pre_dt": "1442038962",
+        "pre_away": "528"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound",
+        "pre_dt": "1442039129",
+        "pre_away": "695"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "pre_dt": "1442039306",
+        "pre_away": "872"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "pre_dt": "1442039546",
+        "pre_away": "1112"
+      }]
+    }, {
+      "trip_id": "28194161",
+      "trip_name": "Alewife to Ashmont",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1740",
+        "vehicle_lat": "42.36122",
+        "vehicle_lon": "-71.07162",
+        "vehicle_bearing": "95",
+        "vehicle_timestamp": "1442038372"
+      },
+      "stop": [{
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "pre_dt": "1442038501",
+        "pre_away": "67"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "pre_dt": "1442038602",
+        "pre_away": "168"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "pre_dt": "1442038693",
+        "pre_away": "259"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "pre_dt": "1442038840",
+        "pre_away": "406"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "pre_dt": "1442038969",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound",
+        "pre_dt": "1442039124",
+        "pre_away": "690"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70087",
+        "stop_name": "Savin Hill - Outbound",
+        "pre_dt": "1442039269",
+        "pre_away": "835"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70089",
+        "stop_name": "Fields Corner - Outbound",
+        "pre_dt": "1442039447",
+        "pre_away": "1013"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70091",
+        "stop_name": "Shawmut - Outbound",
+        "pre_dt": "1442039570",
+        "pre_away": "1136"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "pre_dt": "1442039722",
+        "pre_away": "1288"
+      }]
+    }, {
+      "trip_id": "28194535",
+      "trip_name": "1:23 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1879",
+        "vehicle_lat": "42.23131",
+        "vehicle_lon": "-71.00711",
+        "vehicle_bearing": "180",
+        "vehicle_timestamp": "1442038393"
+      },
+      "stop": [{
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442124780",
+        "sch_dep_dt": "1442124780",
+        "pre_dt": "1442038619",
+        "pre_away": "185"
+      }]
+    }, {
+      "trip_id": "28194543",
+      "trip_name": "1:34 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1615",
+        "vehicle_lat": "42.2932",
+        "vehicle_lon": "-71.06586",
+        "vehicle_bearing": "160",
+        "vehicle_timestamp": "1442038380"
+      },
+      "stop": [{
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "sch_arr_dt": "1442124720",
+        "sch_dep_dt": "1442124720",
+        "pre_dt": "1442038532",
+        "pre_away": "98"
+      }]
+    }, {
+      "trip_id": "28194536",
+      "trip_name": "1:38 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1745",
+        "vehicle_lat": "42.3185",
+        "vehicle_lon": "-71.05212",
+        "vehicle_bearing": "170",
+        "vehicle_timestamp": "1442038416"
+      },
+      "stop": [{
+        "stop_sequence": "180",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound",
+        "sch_arr_dt": "1442124840",
+        "sch_dep_dt": "1442124840",
+        "pre_dt": "1442038835",
+        "pre_away": "401"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound",
+        "sch_arr_dt": "1442125020",
+        "sch_dep_dt": "1442125020",
+        "pre_dt": "1442038962",
+        "pre_away": "528"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound",
+        "sch_arr_dt": "1442125200",
+        "sch_dep_dt": "1442125200",
+        "pre_dt": "1442039129",
+        "pre_away": "695"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "sch_arr_dt": "1442125440",
+        "sch_dep_dt": "1442125440",
+        "pre_dt": "1442039306",
+        "pre_away": "872"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442125680",
+        "sch_dep_dt": "1442125680",
+        "pre_dt": "1442039546",
+        "pre_away": "1112"
+      }]
+    }, {
+      "trip_id": "28194544",
+      "trip_name": "1:49 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1740",
+        "vehicle_lat": "42.36122",
+        "vehicle_lon": "-71.07162",
+        "vehicle_bearing": "95",
+        "vehicle_timestamp": "1442038372"
+      },
+      "stop": [{
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "sch_arr_dt": "1442124360",
+        "sch_dep_dt": "1442124360",
+        "pre_dt": "1442038501",
+        "pre_away": "67"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "sch_arr_dt": "1442124480",
+        "sch_dep_dt": "1442124480",
+        "pre_dt": "1442038602",
+        "pre_away": "168"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "sch_arr_dt": "1442124600",
+        "sch_dep_dt": "1442124600",
+        "pre_dt": "1442038693",
+        "pre_away": "259"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442124720",
+        "sch_dep_dt": "1442124720",
+        "pre_dt": "1442038840",
+        "pre_away": "406"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442124840",
+        "sch_dep_dt": "1442124840",
+        "pre_dt": "1442038969",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound",
+        "sch_arr_dt": "1442124960",
+        "sch_dep_dt": "1442124960",
+        "pre_dt": "1442039124",
+        "pre_away": "690"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70087",
+        "stop_name": "Savin Hill - Outbound",
+        "sch_arr_dt": "1442125140",
+        "sch_dep_dt": "1442125140",
+        "pre_dt": "1442039269",
+        "pre_away": "835"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70089",
+        "stop_name": "Fields Corner - Outbound",
+        "sch_arr_dt": "1442125320",
+        "sch_dep_dt": "1442125320",
+        "pre_dt": "1442039447",
+        "pre_away": "1013"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70091",
+        "stop_name": "Shawmut - Outbound",
+        "sch_arr_dt": "1442125500",
+        "sch_dep_dt": "1442125500",
+        "pre_dt": "1442039570",
+        "pre_away": "1136"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "sch_arr_dt": "1442125620",
+        "sch_dep_dt": "1442125620",
+        "pre_dt": "1442039722",
+        "pre_away": "1288"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28194153",
+      "trip_name": "Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1801",
+        "vehicle_lat": "42.37637",
+        "vehicle_lon": "-71.1191",
+        "vehicle_bearing": "300",
+        "vehicle_timestamp": "1442038400"
+      },
+      "stop": [{
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "pre_dt": "1442038484",
+        "pre_away": "50"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "pre_dt": "1442038605",
+        "pre_away": "171"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "pre_dt": "1442038781",
+        "pre_away": "347"
+      }]
+    }, {
+      "trip_id": "28194152",
+      "trip_name": "Ashmont to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1826",
+        "vehicle_lat": "42.3317",
+        "vehicle_lon": "-71.057",
+        "vehicle_bearing": "0",
+        "vehicle_timestamp": "1442038355"
+      },
+      "stop": [{
+        "stop_sequence": "120",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "pre_dt": "1442038456",
+        "pre_away": "22"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "pre_dt": "1442038601",
+        "pre_away": "167"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "pre_dt": "1442038696",
+        "pre_away": "262"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "pre_dt": "1442038788",
+        "pre_away": "354"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "pre_dt": "1442038923",
+        "pre_away": "489"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "pre_dt": "1442039070",
+        "pre_away": "636"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "pre_dt": "1442039224",
+        "pre_away": "790"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "pre_dt": "1442039422",
+        "pre_away": "988"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "pre_dt": "1442039614",
+        "pre_away": "1180"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "pre_dt": "1442039735",
+        "pre_away": "1301"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "pre_dt": "1442039911",
+        "pre_away": "1477"
+      }]
+    }, {
+      "trip_id": "28194540",
+      "trip_name": "1:29 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1801",
+        "vehicle_lat": "42.37637",
+        "vehicle_lon": "-71.1191",
+        "vehicle_bearing": "300",
+        "vehicle_timestamp": "1442038400"
+      },
+      "stop": [{
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442124660",
+        "sch_dep_dt": "1442124660",
+        "pre_dt": "1442038484",
+        "pre_away": "50"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442124840",
+        "sch_dep_dt": "1442124840",
+        "pre_dt": "1442038605",
+        "pre_away": "171"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442125020",
+        "sch_dep_dt": "1442125020",
+        "pre_dt": "1442038781",
+        "pre_away": "347"
+      }]
+    }, {
+      "trip_id": "28194548",
+      "trip_name": "1:46 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1826",
+        "vehicle_lat": "42.3317",
+        "vehicle_lon": "-71.057",
+        "vehicle_bearing": "0",
+        "vehicle_timestamp": "1442038355"
+      },
+      "stop": [{
+        "stop_sequence": "120",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "sch_arr_dt": "1442124000",
+        "sch_dep_dt": "1442124000",
+        "pre_dt": "1442038456",
+        "pre_away": "22"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "sch_arr_dt": "1442124120",
+        "sch_dep_dt": "1442124120",
+        "pre_dt": "1442038601",
+        "pre_away": "167"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "sch_arr_dt": "1442124240",
+        "sch_dep_dt": "1442124240",
+        "pre_dt": "1442038696",
+        "pre_away": "262"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "sch_arr_dt": "1442124360",
+        "sch_dep_dt": "1442124360",
+        "pre_dt": "1442038788",
+        "pre_away": "354"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "sch_arr_dt": "1442124480",
+        "sch_dep_dt": "1442124480",
+        "pre_dt": "1442038923",
+        "pre_away": "489"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "sch_arr_dt": "1442124600",
+        "sch_dep_dt": "1442124600",
+        "pre_dt": "1442039070",
+        "pre_away": "636"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "sch_arr_dt": "1442124720",
+        "sch_dep_dt": "1442124720",
+        "pre_dt": "1442039224",
+        "pre_away": "790"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442124840",
+        "sch_dep_dt": "1442124840",
+        "pre_dt": "1442039422",
+        "pre_away": "988"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442125020",
+        "sch_dep_dt": "1442125020",
+        "pre_dt": "1442039614",
+        "pre_away": "1180"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442125200",
+        "sch_dep_dt": "1442125200",
+        "pre_dt": "1442039735",
+        "pre_away": "1301"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442125380",
+        "sch_dep_dt": "1442125380",
+        "pre_dt": "1442039911",
+        "pre_away": "1477"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }]
+}

--- a/fixtures/late-night/realtime.mbta.com/alerts-blue.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-blue.fixture
@@ -1,0 +1,69 @@
+GET /developer/api/v2/alertsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:32 GMT
+connection: close
+content-length: 1980
+
+{
+  "alerts": [{
+    "alert_id": 93195,
+    "effect_name": "Service Change",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/riding_the_t/default.asp?id=26899",
+    "description_text": "As part of the project to make Government Center Station fully accessible, all passengers will board and exit on the westbound platform at Bowdoin Station from start to end of service during the following weekends:\r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015\r\n\r\nThe eastbound platform at Bowdoin will be available the following Mondays. The Government Center shuttle bus between State, Government Center, Bowdoin, and Haymarket is unaffected by this service change.\r\n\r\nAffected stops:\r\nBowdoin",
+    "severity": "Minor",
+    "created_dt": "1441904256",
+    "last_modified_dt": "1441904256",
+    "service_effect_text": "Blue Line notice",
+    "timeframe_text": "starting tomorrow",
+    "alert_lifecycle": "Upcoming",
+    "recurrence_text": "weekends",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442125800"
+    }, {
+      "effect_start": "1442133000",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442651400",
+      "effect_end": "1442730600"
+    }, {
+      "effect_start": "1442737800",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1443256200",
+      "effect_end": "1443335400"
+    }, {
+      "effect_start": "1443342600",
+      "effect_end": "1443421800"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Blue",
+        "route_name": "Blue Line",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Blue",
+  "route_name": "Blue Line"
+}

--- a/fixtures/late-night/realtime.mbta.com/alerts-green-b.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-green-b.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-B&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:39 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-B","route_name":"Green Line B"}

--- a/fixtures/late-night/realtime.mbta.com/alerts-green-c.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-green-c.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-C&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:38 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-C","route_name":"Green Line C"}

--- a/fixtures/late-night/realtime.mbta.com/alerts-green-d.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-green-d.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-D&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:38 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-D","route_name":"Green Line D"}

--- a/fixtures/late-night/realtime.mbta.com/alerts-green-e.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-green-e.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-E&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:38 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-E","route_name":"Green Line E"}

--- a/fixtures/late-night/realtime.mbta.com/alerts-orange.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-orange.fixture
@@ -1,0 +1,289 @@
+GET /developer/api/v2/alertsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:34 GMT
+connection: close
+content-length: 9004
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90254,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Oak Grove and Sullivan Stations on September 13-17, 20-24, and 27-30 as well as October 1, 4-8, 11-15, 19-22, and 25-29 from approximately 8:45 p.m. through the end of service",
+    "short_header_text": "Buses replacing Orange Ln between Oak Grove & Sullivan on Sep 13-17, 20-24, & 27-30 & Oct 1, 4-8, 11-15, 19-22, & 25-29 from about 8:45pm un",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing work as part of the Winter Resiliency Improvement Program, alternate shuttle buses will replace Orange Line trains in both directions from Sullivan to Oak Grove Stations beginning at approximately 8:45 p.m. through the end of service on the following dates: \r\n\r\n- Sunday, September 13, 2015, through Thursday, September 17, 2015. \r\n- Sunday, September 20, 2015, through Thursday, September 24, 2015. \r\n- Sunday, September 27, 2015, through Thursday, October 1, 2015.\r\n- Sunday, October 4, 2015, through Thursday, October 8, 2015.\r\n- Sunday, October 11, 2015, through Thursday, October 15, 2015\r\n- Monday, October 19, 2015, through Thursday, October 22, 2015\r\n- Sunday, October 25, 2015, through Thursday, October 29, 2015.\r\n\r\nRegular Orange Line trains will resume at the start of service the next day. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nOak Grove\r\nMalden Center\r\nWellington\r\nAssembly\r\nSullivan Square",
+    "severity": "Severe",
+    "created_dt": "1439849389",
+    "last_modified_dt": "1441969989",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "starting Sunday",
+    "alert_lifecycle": "Upcoming",
+    "recurrence_text": "Sunday-Thursday",
+    "effect_periods": [{
+      "effect_start": "1442191500",
+      "effect_end": "1442212200"
+    }, {
+      "effect_start": "1442277900",
+      "effect_end": "1442298600"
+    }, {
+      "effect_start": "1442364300",
+      "effect_end": "1442385000"
+    }, {
+      "effect_start": "1442450700",
+      "effect_end": "1442471400"
+    }, {
+      "effect_start": "1442537100",
+      "effect_end": "1442557800"
+    }, {
+      "effect_start": "1442796300",
+      "effect_end": "1442817000"
+    }, {
+      "effect_start": "1442882700",
+      "effect_end": "1442903400"
+    }, {
+      "effect_start": "1442969100",
+      "effect_end": "1442989800"
+    }, {
+      "effect_start": "1443055500",
+      "effect_end": "1443076200"
+    }, {
+      "effect_start": "1443141900",
+      "effect_end": "1443162600"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 92997,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "short_header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Orange Line trains between Forest Hills and Ruggles Stations in both directions from start to end of service beginning Saturday, October 17, through Sunday, October 18. Regular Red Line train service will resume at the start of service on Monday, October 19. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops: \r\nRuggles\r\nRoxbury Crossing\r\nJackson Square\r\nStony Brook\r\nGreen Street\r\nForest Hills",
+    "severity": "Severe",
+    "created_dt": "1441809730",
+    "last_modified_dt": "1441809730",
+    "service_effect_text": "Orange Line shuttle",
+    "timeframe_text": "October 17-18",
+    "alert_lifecycle": "Upcoming",
+    "effect_periods": [{
+      "effect_start": "1445070600",
+      "effect_end": "1445236200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Orange",
+  "route_name": "Orange Line"
+}

--- a/fixtures/late-night/realtime.mbta.com/alerts-red.fixture
+++ b/fixtures/late-night/realtime.mbta.com/alerts-red.fixture
@@ -1,0 +1,167 @@
+GET /developer/api/v2/alertsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:28 GMT
+connection: close
+content-length: 5240
+
+{
+  "alerts": [{
+    "alert_id": 88088,
+    "effect_name": "Station Issue",
+    "effect": "UNKNOWN_EFFECT",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+    "description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+    "severity": "Minor",
+    "created_dt": "1438373070",
+    "last_modified_dt": "1439920033",
+    "service_effect_text": "Change at Downtown Crossing",
+    "timeframe_text": "ongoing",
+    "alert_lifecycle": "Ongoing",
+    "effect_periods": [{
+      "effect_start": "1439195400",
+      "effect_end": ""
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Orange",
+        "route_name": "Orange Line",
+        "stop_id": "70021",
+        "stop_name": "Downtown Crossing - to Oak Grove"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife"
+      }],
+      "elevators": []
+    }
+  }, {
+    "alert_id": 90418,
+    "effect_name": "Shuttle",
+    "effect": "DETOUR",
+    "cause_name": "construction",
+    "cause": "CONSTRUCTION",
+    "header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "short_header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sep 12-13, 19-20, and 26-27 from start to end of service.",
+    "url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+    "description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Red Line trains between JFK/UMass and Quincy Center Stations in both directions from start to end of service during the following weekends: \r\n\r\n- Saturday, September 12, 2015, through Sunday, September 13, 2015.\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015.\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015. \r\n\r\nRegular Red Line train service will resume at the start of service on Mondays. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nJFK/UMass\r\nNorth Quincy\r\nWollaston\r\nQuincy Center",
+    "severity": "Severe",
+    "created_dt": "1439993541",
+    "last_modified_dt": "1441965786",
+    "service_effect_text": "Red Line shuttle",
+    "timeframe_text": "this weekend",
+    "alert_lifecycle": "Upcoming",
+    "effect_periods": [{
+      "effect_start": "1442046600",
+      "effect_end": "1442212200"
+    }],
+    "affected_services": {
+      "services": [{
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70086",
+        "stop_name": "JFK/UMASS Ashmont - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70095",
+        "stop_name": "JFK/UMASS Braintree - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70096",
+        "stop_name": "JFK/UMASS Braintree - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70098",
+        "stop_name": "North Quincy - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70100",
+        "stop_name": "Wollaston - Inbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound"
+      }, {
+        "route_type": "1",
+        "mode_name": "Subway",
+        "route_id": "Red",
+        "route_name": "Red Line",
+        "stop_id": "70102",
+        "stop_name": "Quincy Center - Inbound"
+      }],
+      "elevators": []
+    }
+  }],
+  "route_id": "Red",
+  "route_name": "Red Line"
+}

--- a/fixtures/late-night/realtime.mbta.com/predictions-blue.fixture
+++ b/fixtures/late-night/realtime.mbta.com/predictions-blue.fixture
@@ -1,0 +1,416 @@
+GET /developer/api/v2/predictionsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:32 GMT
+connection: close
+content-length: 8228
+
+{
+  "route_id": "Blue",
+  "route_name": "Blue Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Westbound",
+    "trip": [{
+      "trip_id": "28188653",
+      "trip_name": "1:24 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "vehicle": {
+        "vehicle_id": "0700",
+        "vehicle_lat": "42.39601",
+        "vehicle_lon": "-70.9934",
+        "vehicle_bearing": "210",
+        "vehicle_timestamp": "1442035877"
+      },
+      "stop": [{
+        "stop_sequence": "30",
+        "stop_id": "70053",
+        "stop_name": "Suffolk Downs - Inbound",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442035930",
+        "pre_away": "48"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70051",
+        "stop_name": "Orient Heights - Inbound",
+        "sch_arr_dt": "1442035740",
+        "sch_dep_dt": "1442035740",
+        "pre_dt": "1442036022",
+        "pre_away": "140"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70049",
+        "stop_name": "Wood Island - Inbound",
+        "sch_arr_dt": "1442035860",
+        "sch_dep_dt": "1442035860",
+        "pre_dt": "1442036195",
+        "pre_away": "313"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70047",
+        "stop_name": "Airport - Inbound",
+        "sch_arr_dt": "1442035980",
+        "sch_dep_dt": "1442035980",
+        "pre_dt": "1442036294",
+        "pre_away": "412"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70045",
+        "stop_name": "Maverick - Inbound",
+        "sch_arr_dt": "1442036100",
+        "sch_dep_dt": "1442036100",
+        "pre_dt": "1442036439",
+        "pre_away": "557"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442036220",
+        "sch_dep_dt": "1442036220",
+        "pre_dt": "1442036579",
+        "pre_away": "697"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036657",
+        "pre_away": "775"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036791",
+        "pre_away": "909"
+      }]
+    }, {
+      "trip_id": "28188642",
+      "trip_name": "1:40 am from Wonderland to Bowdoin",
+      "trip_headsign": "Bowdoin",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442036400",
+        "sch_dep_dt": "1442036400",
+        "pre_dt": "1442036448",
+        "pre_away": "566"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70057",
+        "stop_name": "Revere Beach - Inbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036484",
+        "pre_away": "602"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70055",
+        "stop_name": "Beachmont - Inbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036602",
+        "pre_away": "720"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70053",
+        "stop_name": "Suffolk Downs - Inbound",
+        "sch_arr_dt": "1442036640",
+        "sch_dep_dt": "1442036640",
+        "pre_dt": "1442036690",
+        "pre_away": "808"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70051",
+        "stop_name": "Orient Heights - Inbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442036782",
+        "pre_away": "900"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70049",
+        "stop_name": "Wood Island - Inbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442036955",
+        "pre_away": "1073"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70047",
+        "stop_name": "Airport - Inbound",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442037054",
+        "pre_away": "1172"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70045",
+        "stop_name": "Maverick - Inbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037199",
+        "pre_away": "1317"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70043",
+        "stop_name": "Aquarium - Inbound",
+        "sch_arr_dt": "1442037180",
+        "sch_dep_dt": "1442037180",
+        "pre_dt": "1442037339",
+        "pre_away": "1457"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70041",
+        "stop_name": "State Street - to Bowdoin",
+        "sch_arr_dt": "1442037240",
+        "sch_dep_dt": "1442037240",
+        "pre_dt": "1442037417",
+        "pre_away": "1535"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Eastbound",
+    "trip": [{
+      "trip_id": "28188643",
+      "trip_name": "1:16 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "vehicle": {
+        "vehicle_id": "0704",
+        "vehicle_lat": "42.39066",
+        "vehicle_lon": "-70.99699",
+        "vehicle_bearing": "35",
+        "vehicle_timestamp": "1442035866"
+      },
+      "stop": [{
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442035980",
+        "sch_dep_dt": "1442035980",
+        "pre_dt": "1442035950",
+        "pre_away": "68"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442036100",
+        "sch_dep_dt": "1442036100",
+        "pre_dt": "1442036075",
+        "pre_away": "193"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442036220",
+        "sch_dep_dt": "1442036220",
+        "pre_dt": "1442036173",
+        "pre_away": "291"
+      }]
+    }, {
+      "trip_id": "28188638",
+      "trip_name": "1:32 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442035920",
+        "sch_dep_dt": "1442035920",
+        "pre_dt": "1442035920",
+        "pre_away": "38"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036000",
+        "pre_away": "118"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036087",
+        "pre_away": "205"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "sch_arr_dt": "1442036340",
+        "sch_dep_dt": "1442036340",
+        "pre_dt": "1442036255",
+        "pre_away": "373"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036390",
+        "pre_away": "508"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442036496",
+        "pre_away": "614"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442036661",
+        "pre_away": "779"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442036750",
+        "pre_away": "868"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442036834",
+        "pre_away": "952"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442036959",
+        "pre_away": "1077"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442037180",
+        "sch_dep_dt": "1442037180",
+        "pre_dt": "1442037057",
+        "pre_away": "1175"
+      }]
+    }, {
+      "trip_id": "28188651",
+      "trip_name": "1:49 am from Bowdoin to Wonderland",
+      "trip_headsign": "Wonderland",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70038",
+        "stop_name": "Bowdoin",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442036949",
+        "pre_away": "1067"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70042",
+        "stop_name": "State Street - to Wonderland",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037029",
+        "pre_away": "1147"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70044",
+        "stop_name": "Aquarium - Outbound",
+        "sch_arr_dt": "1442037180",
+        "sch_dep_dt": "1442037180",
+        "pre_dt": "1442037116",
+        "pre_away": "1234"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70046",
+        "stop_name": "Maverick - Outbound",
+        "sch_arr_dt": "1442037360",
+        "sch_dep_dt": "1442037360",
+        "pre_dt": "1442037284",
+        "pre_away": "1402"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70048",
+        "stop_name": "Airport - Outbound",
+        "sch_arr_dt": "1442037480",
+        "sch_dep_dt": "1442037480",
+        "pre_dt": "1442037419",
+        "pre_away": "1537"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70050",
+        "stop_name": "Wood Island - Outbound",
+        "sch_arr_dt": "1442037600",
+        "sch_dep_dt": "1442037600",
+        "pre_dt": "1442037525",
+        "pre_away": "1643"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70052",
+        "stop_name": "Orient Heights - Outbound",
+        "sch_arr_dt": "1442037720",
+        "sch_dep_dt": "1442037720",
+        "pre_dt": "1442037690",
+        "pre_away": "1808"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70054",
+        "stop_name": "Suffolk Downs - Outbound",
+        "sch_arr_dt": "1442037840",
+        "sch_dep_dt": "1442037840",
+        "pre_dt": "1442037779",
+        "pre_away": "1897"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70056",
+        "stop_name": "Beachmont - Outbound",
+        "sch_arr_dt": "1442037960",
+        "sch_dep_dt": "1442037960",
+        "pre_dt": "1442037863",
+        "pre_away": "1981"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70058",
+        "stop_name": "Revere Beach - Outbound",
+        "sch_arr_dt": "1442038080",
+        "sch_dep_dt": "1442038080",
+        "pre_dt": "1442037988",
+        "pre_away": "2106"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70060",
+        "stop_name": "Wonderland",
+        "sch_arr_dt": "1442038200",
+        "sch_dep_dt": "1442038200",
+        "pre_dt": "1442038086",
+        "pre_away": "2204"
+      }]
+    }]
+  }],
+  "alert_headers": []
+}

--- a/fixtures/late-night/realtime.mbta.com/predictions-orange.fixture
+++ b/fixtures/late-night/realtime.mbta.com/predictions-orange.fixture
@@ -1,0 +1,577 @@
+GET /developer/api/v2/predictionsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:34 GMT
+connection: close
+content-length: 12174
+
+{
+  "route_id": "Orange",
+  "route_name": "Orange Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28190954",
+      "trip_name": "1:10 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "vehicle": {
+        "vehicle_id": "1233",
+        "vehicle_lat": "42.36912",
+        "vehicle_lon": "-71.06371",
+        "vehicle_bearing": "150",
+        "vehicle_timestamp": "1442035865"
+      },
+      "stop": [{
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442035320",
+        "sch_dep_dt": "1442035320",
+        "pre_dt": "1442035905",
+        "pre_away": "23"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442035380",
+        "sch_dep_dt": "1442035380",
+        "pre_dt": "1442035975",
+        "pre_away": "93"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442035440",
+        "sch_dep_dt": "1442035440",
+        "pre_dt": "1442036060",
+        "pre_away": "178"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442035560",
+        "sch_dep_dt": "1442035560",
+        "pre_dt": "1442036131",
+        "pre_away": "249"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442036204",
+        "pre_away": "322"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70016",
+        "stop_name": "Tufts Medical Center - Outbound",
+        "sch_arr_dt": "1442035740",
+        "sch_dep_dt": "1442035740",
+        "pre_dt": "1442036269",
+        "pre_away": "387"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70014",
+        "stop_name": "Back Bay - Outbound",
+        "sch_arr_dt": "1442035860",
+        "sch_dep_dt": "1442035860",
+        "pre_dt": "1442036381",
+        "pre_away": "499"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70012",
+        "stop_name": "Massachusetts Avenue - Outbound",
+        "sch_arr_dt": "1442035980",
+        "sch_dep_dt": "1442035980",
+        "pre_dt": "1442036521",
+        "pre_away": "639"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70010",
+        "stop_name": "Ruggles - Outbound",
+        "sch_arr_dt": "1442036100",
+        "sch_dep_dt": "1442036100",
+        "pre_dt": "1442036602",
+        "pre_away": "720"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70008",
+        "stop_name": "Roxbury Crossing - Outbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036698",
+        "pre_away": "816"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70006",
+        "stop_name": "Jackson Square - Outbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036789",
+        "pre_away": "907"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70004",
+        "stop_name": "Stony Brook - Outbound",
+        "sch_arr_dt": "1442036340",
+        "sch_dep_dt": "1442036340",
+        "pre_dt": "1442036899",
+        "pre_away": "1017"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70002",
+        "stop_name": "Green Street - Outbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036987",
+        "pre_away": "1105"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442037126",
+        "pre_away": "1244"
+      }]
+    }, {
+      "trip_id": "28190957",
+      "trip_name": "1:29 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442035740",
+        "sch_dep_dt": "1442035740",
+        "pre_dt": "1442035999",
+        "pre_away": "117"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442035860",
+        "sch_dep_dt": "1442035860",
+        "pre_dt": "1442036097",
+        "pre_away": "215"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036315",
+        "pre_away": "433"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442036100",
+        "sch_dep_dt": "1442036100",
+        "pre_dt": "1442036442",
+        "pre_away": "560"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442036220",
+        "sch_dep_dt": "1442036220",
+        "pre_dt": "1442036562",
+        "pre_away": "680"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442036340",
+        "sch_dep_dt": "1442036340",
+        "pre_dt": "1442036685",
+        "pre_away": "803"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036814",
+        "pre_away": "932"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036884",
+        "pre_away": "1002"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442036969",
+        "pre_away": "1087"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442037040",
+        "pre_away": "1158"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442037113",
+        "pre_away": "1231"
+      }]
+    }, {
+      "trip_id": "28190958",
+      "trip_name": "1:49 am from Oak Grove to Forest Hills Orange Line",
+      "trip_headsign": "Forest Hills",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442036970",
+        "pre_away": "1088"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70034",
+        "stop_name": "Malden - Inbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037068",
+        "pre_away": "1186"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70032",
+        "stop_name": "Wellington - Inbound",
+        "sch_arr_dt": "1442037240",
+        "sch_dep_dt": "1442037240",
+        "pre_dt": "1442037286",
+        "pre_away": "1404"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70278",
+        "stop_name": "Assembly - Inbound",
+        "sch_arr_dt": "1442037300",
+        "sch_dep_dt": "1442037300",
+        "pre_dt": "1442037413",
+        "pre_away": "1531"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70030",
+        "stop_name": "Sullivan Square - Inbound",
+        "sch_arr_dt": "1442037420",
+        "sch_dep_dt": "1442037420",
+        "pre_dt": "1442037533",
+        "pre_away": "1651"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70028",
+        "stop_name": "Community College - Inbound",
+        "sch_arr_dt": "1442037540",
+        "sch_dep_dt": "1442037540",
+        "pre_dt": "1442037656",
+        "pre_away": "1774"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70026",
+        "stop_name": "North Station - Orange Line Inbound",
+        "sch_arr_dt": "1442037660",
+        "sch_dep_dt": "1442037660",
+        "pre_dt": "1442037785",
+        "pre_away": "1903"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70024",
+        "stop_name": "Haymarket - Orange Line Inbound",
+        "sch_arr_dt": "1442037720",
+        "sch_dep_dt": "1442037720",
+        "pre_dt": "1442037855",
+        "pre_away": "1973"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70022",
+        "stop_name": "State Street - to Forest Hills",
+        "sch_arr_dt": "1442037780",
+        "sch_dep_dt": "1442037780",
+        "pre_dt": "1442037940",
+        "pre_away": "2058"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70020",
+        "stop_name": "Downtown Crossing - to Forest Hills",
+        "sch_arr_dt": "1442037900",
+        "sch_dep_dt": "1442037900",
+        "pre_dt": "1442038011",
+        "pre_away": "2129"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70018",
+        "stop_name": "Chinatown - Outbound",
+        "sch_arr_dt": "1442038020",
+        "sch_dep_dt": "1442038020",
+        "pre_dt": "1442038084",
+        "pre_away": "2202"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28190952",
+      "trip_name": "1:10 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "vehicle": {
+        "vehicle_id": "1227",
+        "vehicle_lat": "42.36514",
+        "vehicle_lon": "-71.05999",
+        "vehicle_bearing": "330",
+        "vehicle_timestamp": "1442035870"
+      },
+      "stop": [{
+        "stop_sequence": "140",
+        "stop_id": "70029",
+        "stop_name": "Community College - Outbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036005",
+        "pre_away": "123"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70031",
+        "stop_name": "Sullivan Square - Outbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036130",
+        "pre_away": "248"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70279",
+        "stop_name": "Assembly - Outbound",
+        "sch_arr_dt": "1442036220",
+        "sch_dep_dt": "1442036220",
+        "pre_dt": "1442036236",
+        "pre_away": "354"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70033",
+        "stop_name": "Wellington - Outbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036365",
+        "pre_away": "483"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70035",
+        "stop_name": "Malden - Outbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036602",
+        "pre_away": "720"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70036",
+        "stop_name": "Oak Grove",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442036773",
+        "pre_away": "891"
+      }]
+    }, {
+      "trip_id": "28190955",
+      "trip_name": "1:30 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442035800",
+        "sch_dep_dt": "1442035800",
+        "pre_dt": "1442035991",
+        "pre_away": "109"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442035920",
+        "sch_dep_dt": "1442035920",
+        "pre_dt": "1442036085",
+        "pre_away": "203"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036177",
+        "pre_away": "295"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036280",
+        "pre_away": "398"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036394",
+        "pre_away": "512"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442036400",
+        "sch_dep_dt": "1442036400",
+        "pre_dt": "1442036495",
+        "pre_away": "613"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036584",
+        "pre_away": "702"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442036640",
+        "sch_dep_dt": "1442036640",
+        "pre_dt": "1442036709",
+        "pre_away": "827"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442036760",
+        "sch_dep_dt": "1442036760",
+        "pre_dt": "1442036834",
+        "pre_away": "952"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442036918",
+        "pre_away": "1036"
+      }]
+    }, {
+      "trip_id": "28190956",
+      "trip_name": "1:45 am from Forest Hills Orange Line to Oak Grove",
+      "trip_headsign": "Oak Grove",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70001",
+        "stop_name": "Forest Hills Orange Line",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442037290",
+        "pre_away": "1408"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70003",
+        "stop_name": "Green Street - Inbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442037384",
+        "pre_away": "1502"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70005",
+        "stop_name": "Stony Brook - Inbound",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442037476",
+        "pre_away": "1594"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70007",
+        "stop_name": "Jackson Square - Inbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037579",
+        "pre_away": "1697"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70009",
+        "stop_name": "Roxbury Crossing - Inbound",
+        "sch_arr_dt": "1442037180",
+        "sch_dep_dt": "1442037180",
+        "pre_dt": "1442037693",
+        "pre_away": "1811"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70011",
+        "stop_name": "Ruggles - Inbound",
+        "sch_arr_dt": "1442037300",
+        "sch_dep_dt": "1442037300",
+        "pre_dt": "1442037794",
+        "pre_away": "1912"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70013",
+        "stop_name": "Massachusetts Avenue - Inbound",
+        "sch_arr_dt": "1442037420",
+        "sch_dep_dt": "1442037420",
+        "pre_dt": "1442037883",
+        "pre_away": "2001"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70015",
+        "stop_name": "Back Bay - Inbound",
+        "sch_arr_dt": "1442037540",
+        "sch_dep_dt": "1442037540",
+        "pre_dt": "1442038008",
+        "pre_away": "2126"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70017",
+        "stop_name": "Tufts Medical Center - Inbound",
+        "sch_arr_dt": "1442037660",
+        "sch_dep_dt": "1442037660",
+        "pre_dt": "1442038133",
+        "pre_away": "2251"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70019",
+        "stop_name": "Chinatown - Inbound",
+        "sch_arr_dt": "1442037720",
+        "sch_dep_dt": "1442037720",
+        "pre_dt": "1442038217",
+        "pre_away": "2335"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }]
+}

--- a/fixtures/late-night/realtime.mbta.com/predictions-red.fixture
+++ b/fixtures/late-night/realtime.mbta.com/predictions-red.fixture
@@ -1,0 +1,758 @@
+GET /developer/api/v2/predictionsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Sat, 12 Sep 2015 05:31:24 GMT
+connection: close
+content-length: 15606
+
+{
+  "route_id": "Red",
+  "route_name": "Red Line",
+  "route_type": "1",
+  "mode_name": "Subway",
+  "direction": [{
+    "direction_id": "0",
+    "direction_name": "Southbound",
+    "trip": [{
+      "trip_id": "28194149",
+      "trip_name": "1:01 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1863",
+        "vehicle_lat": "42.34157",
+        "vehicle_lon": "-71.05711",
+        "vehicle_bearing": "175",
+        "vehicle_timestamp": "1442035840"
+      },
+      "stop": [{
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442035560",
+        "sch_dep_dt": "1442035560",
+        "pre_dt": "1442035942",
+        "pre_away": "60"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70095",
+        "stop_name": "JFK/UMASS Braintree - Outbound",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442036090",
+        "pre_away": "208"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound",
+        "sch_arr_dt": "1442036100",
+        "sch_dep_dt": "1442036100",
+        "pre_dt": "1442036555",
+        "pre_away": "673"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036682",
+        "pre_away": "800"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036863",
+        "pre_away": "981"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442037039",
+        "pre_away": "1157"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442037312",
+        "pre_away": "1430"
+      }]
+    }, {
+      "trip_id": "28194155",
+      "trip_name": "1:11 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "vehicle": {
+        "vehicle_id": "1804",
+        "vehicle_lat": "42.36122",
+        "vehicle_lon": "-71.07162",
+        "vehicle_bearing": "95",
+        "vehicle_timestamp": "1442035870"
+      },
+      "stop": [{
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442035978",
+        "pre_away": "96"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "sch_arr_dt": "1442035800",
+        "sch_dep_dt": "1442035800",
+        "pre_dt": "1442036057",
+        "pre_away": "175"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "sch_arr_dt": "1442035920",
+        "sch_dep_dt": "1442035920",
+        "pre_dt": "1442036136",
+        "pre_away": "254"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036271",
+        "pre_away": "389"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036391",
+        "pre_away": "509"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70085",
+        "stop_name": "JFK/UMASS Ashmont - Outbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036536",
+        "pre_away": "654"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70087",
+        "stop_name": "Savin Hill - Outbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036682",
+        "pre_away": "800"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70089",
+        "stop_name": "Fields Corner - Outbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036860",
+        "pre_away": "978"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70091",
+        "stop_name": "Shawmut - Outbound",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442037002",
+        "pre_away": "1120"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70093",
+        "stop_name": "Ashmont - Outbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442037154",
+        "pre_away": "1272"
+      }]
+    }, {
+      "trip_id": "28194157",
+      "trip_name": "1:23 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "vehicle": {
+        "vehicle_id": "1879",
+        "vehicle_lat": "42.3961",
+        "vehicle_lon": "-71.12073",
+        "vehicle_bearing": "150",
+        "vehicle_timestamp": "1442035872"
+      },
+      "stop": [{
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442035928",
+        "pre_away": "46"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442035860",
+        "sch_dep_dt": "1442035860",
+        "pre_dt": "1442036092",
+        "pre_away": "210"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036305",
+        "pre_away": "423"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036479",
+        "pre_away": "597"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70073",
+        "stop_name": "Charles/MGH - Inbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036618",
+        "pre_away": "736"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70075",
+        "stop_name": "Park Street - to Ashmont/Braintree",
+        "sch_arr_dt": "1442036400",
+        "sch_dep_dt": "1442036400",
+        "pre_dt": "1442036726",
+        "pre_away": "844"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70077",
+        "stop_name": "Downtown Crossing - to Ashmont/Braintree",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036805",
+        "pre_away": "923"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70079",
+        "stop_name": "South Station - Outbound",
+        "sch_arr_dt": "1442036640",
+        "sch_dep_dt": "1442036640",
+        "pre_dt": "1442036884",
+        "pre_away": "1002"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70081",
+        "stop_name": "Broadway - Outbound",
+        "sch_arr_dt": "1442036760",
+        "sch_dep_dt": "1442036760",
+        "pre_dt": "1442037019",
+        "pre_away": "1137"
+      }, {
+        "stop_sequence": "110",
+        "stop_id": "70083",
+        "stop_name": "Andrew - Outbound",
+        "sch_arr_dt": "1442036880",
+        "sch_dep_dt": "1442036880",
+        "pre_dt": "1442037139",
+        "pre_away": "1257"
+      }, {
+        "stop_sequence": "120",
+        "stop_id": "70095",
+        "stop_name": "JFK/UMASS Braintree - Outbound",
+        "sch_arr_dt": "1442037000",
+        "sch_dep_dt": "1442037000",
+        "pre_dt": "1442037287",
+        "pre_away": "1405"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70097",
+        "stop_name": "North Quincy - Outbound",
+        "sch_arr_dt": "1442037420",
+        "sch_dep_dt": "1442037420",
+        "pre_dt": "1442037752",
+        "pre_away": "1870"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70099",
+        "stop_name": "Wollaston - Outbound",
+        "sch_arr_dt": "1442037600",
+        "sch_dep_dt": "1442037600",
+        "pre_dt": "1442037879",
+        "pre_away": "1997"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70101",
+        "stop_name": "Quincy Center - Outbound",
+        "sch_arr_dt": "1442037780",
+        "sch_dep_dt": "1442037780",
+        "pre_dt": "1442038060",
+        "pre_away": "2178"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70103",
+        "stop_name": "Quincy Adams - Outbound",
+        "sch_arr_dt": "1442038020",
+        "sch_dep_dt": "1442038020",
+        "pre_dt": "1442038236",
+        "pre_away": "2354"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70105",
+        "stop_name": "Braintree",
+        "sch_arr_dt": "1442038260",
+        "sch_dep_dt": "1442038260",
+        "pre_dt": "1442038509",
+        "pre_away": "2627"
+      }]
+    }, {
+      "trip_id": "28194146",
+      "trip_name": "1:34 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036335",
+        "pre_away": "453"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "sch_arr_dt": "1442036220",
+        "sch_dep_dt": "1442036220",
+        "pre_dt": "1442036417",
+        "pre_away": "535"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442036340",
+        "sch_dep_dt": "1442036340",
+        "pre_dt": "1442036542",
+        "pre_away": "660"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036706",
+        "pre_away": "824"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442036919",
+        "pre_away": "1037"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442036820",
+        "sch_dep_dt": "1442036820",
+        "pre_dt": "1442037093",
+        "pre_away": "1211"
+      }]
+    }, {
+      "trip_id": "28194160",
+      "trip_name": "1:38 am from Alewife to Braintree",
+      "trip_headsign": "Braintree",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036661",
+        "pre_away": "779"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036743",
+        "pre_away": "861"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442036580",
+        "sch_dep_dt": "1442036580",
+        "pre_dt": "1442036865",
+        "pre_away": "983"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442036760",
+        "sch_dep_dt": "1442036760",
+        "pre_dt": "1442037029",
+        "pre_away": "1147"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442037242",
+        "pre_away": "1360"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037416",
+        "pre_away": "1534"
+      }]
+    }, {
+      "trip_id": "28194161",
+      "trip_name": "1:49 am from Alewife to Ashmont - Outbound",
+      "trip_headsign": "Ashmont",
+      "stop": [{
+        "stop_sequence": "1",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442036940",
+        "sch_dep_dt": "1442036940",
+        "pre_dt": "1442037106",
+        "pre_away": "1224"
+      }, {
+        "stop_sequence": "10",
+        "stop_id": "70063",
+        "stop_name": "Davis - Inbound",
+        "sch_arr_dt": "1442037120",
+        "sch_dep_dt": "1442037120",
+        "pre_dt": "1442037188",
+        "pre_away": "1306"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70065",
+        "stop_name": "Porter - Inbound",
+        "sch_arr_dt": "1442037240",
+        "sch_dep_dt": "1442037240",
+        "pre_dt": "1442037312",
+        "pre_away": "1430"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70067",
+        "stop_name": "Harvard - Inbound",
+        "sch_arr_dt": "1442037420",
+        "sch_dep_dt": "1442037420",
+        "pre_dt": "1442037476",
+        "pre_away": "1594"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70069",
+        "stop_name": "Central - Inbound",
+        "sch_arr_dt": "1442037600",
+        "sch_dep_dt": "1442037600",
+        "pre_dt": "1442037689",
+        "pre_away": "1807"
+      }, {
+        "stop_sequence": "50",
+        "stop_id": "70071",
+        "stop_name": "Kendall/MIT - Inbound",
+        "sch_arr_dt": "1442037720",
+        "sch_dep_dt": "1442037720",
+        "pre_dt": "1442037863",
+        "pre_away": "1981"
+      }]
+    }]
+  }, {
+    "direction_id": "1",
+    "direction_name": "Northbound",
+    "trip": [{
+      "trip_id": "28194156",
+      "trip_name": "12:50 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1712",
+        "vehicle_lat": "42.36953",
+        "vehicle_lon": "-71.11154",
+        "vehicle_bearing": "300",
+        "vehicle_timestamp": "1442035857"
+      },
+      "stop": [{
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442035680",
+        "sch_dep_dt": "1442035680",
+        "pre_dt": "1442035946",
+        "pre_away": "64"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442035860",
+        "sch_dep_dt": "1442035860",
+        "pre_dt": "1442036130",
+        "pre_away": "248"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036251",
+        "pre_away": "369"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036422",
+        "pre_away": "540"
+      }]
+    }, {
+      "trip_id": "28194159",
+      "trip_name": "12:51 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1717",
+        "vehicle_lat": "42.39082",
+        "vehicle_lon": "-71.1188",
+        "vehicle_bearing": "0",
+        "vehicle_timestamp": "1442035870"
+      },
+      "stop": [{
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442035500",
+        "sch_dep_dt": "1442035500",
+        "pre_dt": "1442035925",
+        "pre_away": "43"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442035740",
+        "sch_dep_dt": "1442035740",
+        "pre_dt": "1442036096",
+        "pre_away": "214"
+      }]
+    }, {
+      "trip_id": "28194154",
+      "trip_name": "1:07 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "vehicle": {
+        "vehicle_id": "1746",
+        "vehicle_lat": "42.33107",
+        "vehicle_lon": "-71.057",
+        "vehicle_bearing": "0",
+        "vehicle_timestamp": "1442035855"
+      },
+      "stop": [{
+        "stop_sequence": "120",
+        "stop_id": "70082",
+        "stop_name": "Broadway - Inbound",
+        "sch_arr_dt": "1442035800",
+        "sch_dep_dt": "1442035800",
+        "pre_dt": "1442035971",
+        "pre_away": "89"
+      }, {
+        "stop_sequence": "130",
+        "stop_id": "70080",
+        "stop_name": "South Station - Inbound",
+        "sch_arr_dt": "1442035920",
+        "sch_dep_dt": "1442035920",
+        "pre_dt": "1442036125",
+        "pre_away": "243"
+      }, {
+        "stop_sequence": "140",
+        "stop_id": "70078",
+        "stop_name": "Downtown Crossing - to Alewife",
+        "sch_arr_dt": "1442036040",
+        "sch_dep_dt": "1442036040",
+        "pre_dt": "1442036204",
+        "pre_away": "322"
+      }, {
+        "stop_sequence": "150",
+        "stop_id": "70076",
+        "stop_name": "Park Street - to Alewife",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036277",
+        "pre_away": "395"
+      }, {
+        "stop_sequence": "160",
+        "stop_id": "70074",
+        "stop_name": "Charles/MGH - Outbound",
+        "sch_arr_dt": "1442036280",
+        "sch_dep_dt": "1442036280",
+        "pre_dt": "1442036404",
+        "pre_away": "522"
+      }, {
+        "stop_sequence": "170",
+        "stop_id": "70072",
+        "stop_name": "Kendall/MIT - Outbound",
+        "sch_arr_dt": "1442036400",
+        "sch_dep_dt": "1442036400",
+        "pre_dt": "1442036543",
+        "pre_away": "661"
+      }, {
+        "stop_sequence": "180",
+        "stop_id": "70070",
+        "stop_name": "Central - Outbound",
+        "sch_arr_dt": "1442036520",
+        "sch_dep_dt": "1442036520",
+        "pre_dt": "1442036695",
+        "pre_away": "813"
+      }, {
+        "stop_sequence": "190",
+        "stop_id": "70068",
+        "stop_name": "Harvard - Outbound",
+        "sch_arr_dt": "1442036700",
+        "sch_dep_dt": "1442036700",
+        "pre_dt": "1442036895",
+        "pre_away": "1013"
+      }, {
+        "stop_sequence": "200",
+        "stop_id": "70066",
+        "stop_name": "Porter - Outbound",
+        "sch_arr_dt": "1442036880",
+        "sch_dep_dt": "1442036880",
+        "pre_dt": "1442037079",
+        "pre_away": "1197"
+      }, {
+        "stop_sequence": "210",
+        "stop_id": "70064",
+        "stop_name": "Davis - Outbound",
+        "sch_arr_dt": "1442037060",
+        "sch_dep_dt": "1442037060",
+        "pre_dt": "1442037200",
+        "pre_away": "1318"
+      }, {
+        "stop_sequence": "220",
+        "stop_id": "70061",
+        "stop_name": "Alewife",
+        "sch_arr_dt": "1442037300",
+        "sch_dep_dt": "1442037300",
+        "pre_dt": "1442037371",
+        "pre_away": "1489"
+      }]
+    }, {
+      "trip_id": "28194153",
+      "trip_name": "1:29 am from Braintree to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "10",
+        "stop_id": "70104",
+        "stop_name": "Quincy Adams - Inbound",
+        "sch_arr_dt": "1442035980",
+        "sch_dep_dt": "1442035980",
+        "pre_dt": "1442036113",
+        "pre_away": "231"
+      }, {
+        "stop_sequence": "20",
+        "stop_id": "70102",
+        "stop_name": "Quincy Center - Inbound",
+        "sch_arr_dt": "1442036160",
+        "sch_dep_dt": "1442036160",
+        "pre_dt": "1442036292",
+        "pre_away": "410"
+      }, {
+        "stop_sequence": "30",
+        "stop_id": "70100",
+        "stop_name": "Wollaston - Inbound",
+        "sch_arr_dt": "1442036340",
+        "sch_dep_dt": "1442036340",
+        "pre_dt": "1442036486",
+        "pre_away": "604"
+      }, {
+        "stop_sequence": "40",
+        "stop_id": "70098",
+        "stop_name": "North Quincy - Inbound",
+        "sch_arr_dt": "1442036460",
+        "sch_dep_dt": "1442036460",
+        "pre_dt": "1442036625",
+        "pre_away": "743"
+      }, {
+        "stop_sequence": "100",
+        "stop_id": "70096",
+        "stop_name": "JFK/UMASS Braintree - Inbound",
+        "sch_arr_dt": "1442036880",
+        "sch_dep_dt": "1442036880",
+        "pre_dt": "1442037108",
+        "pre_away": "1226"
+      }]
+    }, {
+      "trip_id": "28194152",
+      "trip_name": "1:46 am from Ashmont - Inbound to Alewife",
+      "trip_headsign": "Alewife",
+      "stop": [{
+        "stop_sequence": "50",
+        "stop_id": "70094",
+        "stop_name": "Ashmont - Inbound",
+        "sch_arr_dt": "1442036760",
+        "sch_dep_dt": "1442036760",
+        "pre_dt": "1442037511",
+        "pre_away": "1629"
+      }, {
+        "stop_sequence": "60",
+        "stop_id": "70092",
+        "stop_name": "Shawmut - Inbound",
+        "sch_arr_dt": "1442036880",
+        "sch_dep_dt": "1442036880",
+        "pre_dt": "1442037582",
+        "pre_away": "1700"
+      }, {
+        "stop_sequence": "70",
+        "stop_id": "70090",
+        "stop_name": "Fields Corner - Inbound",
+        "sch_arr_dt": "1442037000",
+        "sch_dep_dt": "1442037000",
+        "pre_dt": "1442037689",
+        "pre_away": "1807"
+      }, {
+        "stop_sequence": "80",
+        "stop_id": "70088",
+        "stop_name": "Savin Hill - Inbound",
+        "sch_arr_dt": "1442037180",
+        "sch_dep_dt": "1442037180",
+        "pre_dt": "1442037857",
+        "pre_away": "1975"
+      }, {
+        "stop_sequence": "90",
+        "stop_id": "70086",
+        "stop_name": "JFK/UMASS Ashmont - Inbound",
+        "sch_arr_dt": "1442037300",
+        "sch_dep_dt": "1442037300",
+        "pre_dt": "1442037984",
+        "pre_away": "2102"
+      }]
+    }]
+  }],
+  "alert_headers": [{
+    "alert_id": 88088,
+    "header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+    "effect_name": "Station Issue"
+  }]
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-blue.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-blue.fixture
@@ -1,0 +1,115 @@
+GET /developer/api/v2/alertsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:35 GMT
+connection: close
+content-length: 4021
+
+{
+	"alerts": [{
+		"alert_id": 93195,
+		"effect_name": "Service Change",
+		"effect": "UNKNOWN_EFFECT",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 19-20, 26-27, and Oct 3-4 from start to end of service.",
+		"short_header_text": "All passengers will board and exit on the westbound platform at Bowdoin Sept 19-20, 26-27, and Oct 3-4 from start to end of service.",
+		"url": "http://www.mbta.com/riding_the_t/default.asp?id=26899",
+		"description_text": "As part of the project to make Government Center Station fully accessible, all passengers will board and exit on the westbound platform at Bowdoin Station from start to end of service during the following weekends:\r\n\r\n- Saturday, September 19, 2015, through Sunday, September 20, 2015\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015\r\n- Saturday, October 3, 2015, through Sunday, October 4, 2015 \r\n\r\nThe eastbound platform at Bowdoin will be available the following Mondays. The Government Center shuttle bus between State, Government Center, Bowdoin, and Haymarket is unaffected by this service change.\r\n\r\nAffected stops:\r\nBowdoin",
+		"severity": "Minor",
+		"created_dt": "1441904256",
+		"last_modified_dt": "1442948486",
+		"service_effect_text": "Blue Line notice",
+		"timeframe_text": "starting Saturday",
+		"alert_lifecycle": "Upcoming",
+		"recurrence_text": "2 days a week",
+		"effect_periods": [{
+			"effect_start": "1443256200",
+			"effect_end": "1443335400"
+		}, {
+			"effect_start": "1443342600",
+			"effect_end": "1443421800"
+		}, {
+			"effect_start": "1443861000",
+			"effect_end": "1443940200"
+		}, {
+			"effect_start": "1443947400",
+			"effect_end": "1444026600"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Blue",
+				"route_name": "Blue Line",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin"
+			}],
+			"elevators": []
+		}
+	}, {
+		"alert_id": 95045,
+		"effect_name": "Station Closure",
+		"effect": "NO_SERVICE",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Bowdoin will be closed from start to end of service on Oct 10-11, 17-18, 24-25, and 31-Nov 1. Please board and exit the Blue Line at State during the closure.",
+		"short_header_text": "Bowdoin will be closed all day on Oct 10-11, 17-18, 24-25, and 31-Nov 1. Please board and exit the Blue Line at State during the closure",
+		"description_text": "Due to crews performing necessary work as part of Government Center Project, Bowdoin Station will be closed from start to end of service during the following weekends:\r\n\r\n- Saturday, October 10, 2015, through Sunday, October 11, 2015.\r\n- Saturday, October 17, 2015, through Sunday, October 18, 2015.\r\n- Saturday, October 24, 2015, through Sunday, October 25, 2015.\r\n- Saturday, October 31, 2015, through Sunday, November 1, 2015.\r\n\r\nDuring this time, Blue Line service will terminate/originate at State Station. For westbound service, please exit at State and travel at the street-level to Bowdoin. For eastbound service, please travel at the street-level to State in order to board the Blue Line. Bowdoin will re-open at the start of service the following Monday.\r\n\r\nAffected routes:\r\nBlue Line",
+		"severity": "Severe",
+		"created_dt": "1442943291",
+		"last_modified_dt": "1442943291",
+		"service_effect_text": "Bowdoin closed",
+		"timeframe_text": "starting October 10",
+		"alert_lifecycle": "Upcoming",
+		"recurrence_text": "weekends",
+		"effect_periods": [{
+			"effect_start": "1444465800",
+			"effect_end": "1444545000"
+		}, {
+			"effect_start": "1444552200",
+			"effect_end": "1444631400"
+		}, {
+			"effect_start": "1445070600",
+			"effect_end": "1445149800"
+		}, {
+			"effect_start": "1445157000",
+			"effect_end": "1445236200"
+		}, {
+			"effect_start": "1445675400",
+			"effect_end": "1445754600"
+		}, {
+			"effect_start": "1445761800",
+			"effect_end": "1445841000"
+		}, {
+			"effect_start": "1446280200",
+			"effect_end": "1446363000"
+		}, {
+			"effect_start": "1446370200",
+			"effect_end": "1446449400"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Blue",
+				"route_name": "Blue Line",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin"
+			}],
+			"elevators": []
+		}
+	}],
+	"route_id": "Blue",
+	"route_name": "Blue Line"
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-green-b.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-green-b.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-B&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:39 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-B","route_name":"Green Line B"}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-green-c.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-green-c.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-C&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:39 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-C","route_name":"Green Line C"}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-green-d.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-green-d.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-D&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:39 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-D","route_name":"Green Line D"}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-green-e.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-green-e.fixture
@@ -1,0 +1,18 @@
+GET /developer/api/v2/alertsbyroute?route=Green-E&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:39 GMT
+connection: close
+content-length: 62
+
+{"alerts":[],"route_id":"Green-E","route_name":"Green Line E"}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-orange.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-orange.fixture
@@ -1,0 +1,289 @@
+GET /developer/api/v2/alertsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:36 GMT
+connection: close
+content-length: 8933
+
+{
+	"alerts": [{
+		"alert_id": 88088,
+		"effect_name": "Station Issue",
+		"effect": "UNKNOWN_EFFECT",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+		"short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+		"description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+		"severity": "Minor",
+		"created_dt": "1438373070",
+		"last_modified_dt": "1439920033",
+		"service_effect_text": "Change at Downtown Crossing",
+		"timeframe_text": "ongoing",
+		"alert_lifecycle": "Ongoing",
+		"effect_periods": [{
+			"effect_start": "1439195400",
+			"effect_end": ""
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70021",
+				"stop_name": "Downtown Crossing - to Oak Grove"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70077",
+				"stop_name": "Downtown Crossing - to Ashmont/Braintree"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife"
+			}],
+			"elevators": []
+		}
+	}, {
+		"alert_id": 92997,
+		"effect_name": "Shuttle",
+		"effect": "DETOUR",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+		"short_header_text": "Buses replacing Orange Line service between Forest Hills and Ruggles Stations on October 17-18 from start to end of service.",
+		"url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+		"description_text": "Due to crews performing necessary work as part of the Winter Resiliency Improvement Program, buses will replace Orange Line trains between Forest Hills and Ruggles Stations in both directions from start to end of service beginning Saturday, October 17, through Sunday, October 18. Regular Orange Line train service will resume at the start of service on Monday, October 19. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops: \r\nRuggles\r\nRoxbury Crossing\r\nJackson Square\r\nStony Brook\r\nGreen Street\r\nForest Hills",
+		"severity": "Severe",
+		"created_dt": "1441809730",
+		"last_modified_dt": "1442571262",
+		"service_effect_text": "Orange Line shuttle",
+		"timeframe_text": "October 17-18",
+		"alert_lifecycle": "Upcoming",
+		"effect_periods": [{
+			"effect_start": "1445070600",
+			"effect_end": "1445236200"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound"
+			}],
+			"elevators": []
+		}
+	}, {
+		"alert_id": 94478,
+		"effect_name": "Shuttle",
+		"effect": "DETOUR",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Buses replacing Orange Line service between Oak Grove and Sullivan Stations on September 23-24 and 27-30 as well as October 1, 4-8, 11-15, 19-22, and 25-29 from approximately 8:45 p.m. through the end of service",
+		"short_header_text": "Buses replacing Orange Ln between Oak Grove & Sullivan on Sep 23-24 & 27-30 & Oct 1, 4-8, 11-15, 19-22, & 25-29 from about 8:45pm until clos",
+		"url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+		"description_text": "Due to crews performing work as part of the Winter Resiliency Improvement Program, alternate shuttle buses will replace Orange Line trains in both directions from Sullivan to Oak Grove Stations beginning at approximately 8:45 p.m. through the end of service on the following dates: \r\n\r\n- Wednesday, September 23, 2015, through Thursday, September 24, 2015. \r\n- Sunday, September 27, 2015, through Thursday, October 1, 2015.\r\n- Sunday, October 4, 2015, through Thursday, October 8, 2015.\r\n- Sunday, October 11, 2015, through Thursday, October 15, 2015\r\n- Monday, October 19, 2015, through Thursday, October 22, 2015\r\n- Sunday, October 25, 2015, through Thursday, October 29, 2015.\r\n\r\nRegular Orange Line trains will resume at the start of service the next day. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nOak Grove\r\nMalden Center\r\nWellington\r\nAssembly\r\nSullivan Square",
+		"severity": "Severe",
+		"created_dt": "1442590149",
+		"last_modified_dt": "1443003332",
+		"service_effect_text": "Orange Line shuttle",
+		"timeframe_text": "starting later today",
+		"alert_lifecycle": "Upcoming",
+		"recurrence_text": "5 days a week",
+		"effect_periods": [{
+			"effect_start": "1443141900",
+			"effect_end": "1443162600"
+		}, {
+			"effect_start": "1443401100",
+			"effect_end": "1443421800"
+		}, {
+			"effect_start": "1443487500",
+			"effect_end": "1443508200"
+		}, {
+			"effect_start": "1443573900",
+			"effect_end": "1443594600"
+		}, {
+			"effect_start": "1443660300",
+			"effect_end": "1443681000"
+		}, {
+			"effect_start": "1443746700",
+			"effect_end": "1443767400"
+		}, {
+			"effect_start": "1444005900",
+			"effect_end": "1444026600"
+		}, {
+			"effect_start": "1444092300",
+			"effect_end": "1444113000"
+		}, {
+			"effect_start": "1444178700",
+			"effect_end": "1444199400"
+		}, {
+			"effect_start": "1444265100",
+			"effect_end": "1444285800"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70031",
+				"stop_name": "Sullivan Square - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70279",
+				"stop_name": "Assembly - Outbound"
+			}],
+			"elevators": []
+		}
+	}],
+	"route_id": "Orange",
+	"route_name": "Orange Line"
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/alerts-red.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/alerts-red.fixture
@@ -1,0 +1,193 @@
+GET /developer/api/v2/alertsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:32 GMT
+connection: close
+content-length: 6115
+
+{
+	"alerts": [{
+		"alert_id": 88088,
+		"effect_name": "Station Issue",
+		"effect": "UNKNOWN_EFFECT",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+		"short_header_text": "Downtown Crossing: The Franklin St entrance will be closed on Mon, Aug 10, and will remain closed until Summer 2016 due to construction",
+		"description_text": "Customers desiring to enter and exit at Downtown Crossing should instead utilize entrances and exits on Summer, Chauncy, and Arch Streets. \r\n\r\nCustomers desiring elevator access should note that Elevator 891 will be closed during this construction. If exiting, travel down the concourse to use the elevator through the glass doors and to the left of the CharlieCard Store. This elevator will take you to the lobby of 101 Arch Street. If boarding, travel to 101 Arch Street. Take the elevator in the back left corner of the lobby to the concourse. Take a right to find the Oak Grove-bound platform ahead. Customers can also enter and exit the station using the Roche Bros. elevator on Summer St. (during store hours only).\r\n\r\nAffected routes:\r\nOrange Line\r\nRed Line (Ashmont branch)\r\nRed Line (Braintree branch)",
+		"severity": "Minor",
+		"created_dt": "1438373070",
+		"last_modified_dt": "1439920033",
+		"service_effect_text": "Change at Downtown Crossing",
+		"timeframe_text": "ongoing",
+		"alert_lifecycle": "Ongoing",
+		"effect_periods": [{
+			"effect_start": "1439195400",
+			"effect_end": ""
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Orange",
+				"route_name": "Orange Line",
+				"stop_id": "70021",
+				"stop_name": "Downtown Crossing - to Oak Grove"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70077",
+				"stop_name": "Downtown Crossing - to Ashmont/Braintree"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife"
+			}],
+			"elevators": []
+		}
+	}, {
+		"alert_id": 92194,
+		"effect_name": "Shuttle",
+		"effect": "DETOUR",
+		"cause_name": "construction",
+		"cause": "CONSTRUCTION",
+		"header_text": "Buses replacing Red Line service between JFK/UMass and Quincy Center Stations on Sept 26-27 as well as Oct 3-4, 10-11, 24-25, and 31-Nov 1 from start to end of service.",
+		"short_header_text": "Buses replacing Red Line between JFK/UMass and Quincy Center Stations on Sept 26-27 and Oct 3-4, 10-11, 24-25, and 31-Nov 1 all day",
+		"url": "http://www.mbta.com/about_the_mbta/news_events/?id=6442454500&month=&year=",
+		"description_text": "Due to crews performing necessary performing work as part of the Winter Resiliency Improvement Program, buses will replace Red Line trains between JFK/UMass and Quincy Center Stations in both directions from start to end of service during the following weekends: \r\n\r\n- Saturday, September 26, 2015, through Sunday, September 27, 2015. \r\n- Saturday, October 3, 2015, through Sunday, October 4, 2015. \r\n- Saturday, October 10, 2015, through Sunday, October 11, 2015. \r\n- Saturday, October 24, 2015, through Sunday, October 25, 2015. \r\n- Saturday, October 31, 2015, through Sunday, November 1, 2015. \r\n\r\nRegular Red Line train service will resume at the start of service on Mondays. All shuttle bus stops are accessible for persons with disabilities. \r\n\r\nShuttling the following stops:\r\nJFK/UMass\r\nNorth Quincy\r\nWollaston\r\nQuincy Center",
+		"severity": "Severe",
+		"created_dt": "1441287872",
+		"last_modified_dt": "1443011939",
+		"service_effect_text": "Red Line shuttle",
+		"timeframe_text": "this weekend",
+		"alert_lifecycle": "Upcoming",
+		"effect_periods": [{
+			"effect_start": "1443256200",
+			"effect_end": "1443421800"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70085",
+				"stop_name": "JFK/UMASS Ashmont - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70086",
+				"stop_name": "JFK/UMASS Ashmont - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70095",
+				"stop_name": "JFK/UMASS Braintree - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70097",
+				"stop_name": "North Quincy - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70099",
+				"stop_name": "Wollaston - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70101",
+				"stop_name": "Quincy Center - Outbound"
+			}, {
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound"
+			}],
+			"elevators": []
+		}
+	}, {
+		"alert_id": 95292,
+		"effect_name": "Delay",
+		"effect": "OTHER_EFFECT",
+		"cause_name": "signal problem",
+		"cause": "TECHNICAL_PROBLEM",
+		"header_text": "Red Line experiencing severe delays in both directions due to a signal problem at Alewife Station.",
+		"short_header_text": "Red Line experiencing severe delays in both directions due to a signal problem at Alewife Station.",
+		"severity": "Severe",
+		"created_dt": "1443089561",
+		"last_modified_dt": "1443097983",
+		"service_effect_text": "Severe Red Line delay",
+		"alert_lifecycle": "New",
+		"effect_periods": [{
+			"effect_start": "1443089560",
+			"effect_end": "1443119964"
+		}],
+		"affected_services": {
+			"services": [{
+				"route_type": "1",
+				"mode_name": "Subway",
+				"route_id": "Red",
+				"route_name": "Red Line"
+			}],
+			"elevators": []
+		}
+	}],
+	"route_id": "Red",
+	"route_name": "Red Line"
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/predictions-blue.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/predictions-blue.fixture
@@ -1,0 +1,775 @@
+GET /developer/api/v2/predictionsbyroute?route=Blue&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:35 GMT
+connection: close
+content-length: 15734
+
+{
+	"route_id": "Blue",
+	"route_name": "Blue Line",
+	"route_type": "1",
+	"mode_name": "Subway",
+	"direction": [{
+		"direction_id": "0",
+		"direction_name": "Westbound",
+		"trip": [{
+			"trip_id": "28187836",
+			"trip_name": "10:18 am from Wonderland to Bowdoin",
+			"trip_headsign": "Bowdoin",
+			"vehicle": {
+				"vehicle_id": "0763",
+				"vehicle_lat": "42.35889",
+				"vehicle_lon": "-71.0574",
+				"vehicle_bearing": "275",
+				"vehicle_timestamp": "1443105617"
+			},
+			"stop": [{
+				"stop_sequence": "110",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105794",
+				"pre_away": "101"
+			}]
+		}, {
+			"trip_id": "28187931",
+			"trip_name": "10:26 am from Wonderland to Bowdoin",
+			"trip_headsign": "Bowdoin",
+			"vehicle": {
+				"vehicle_id": "0793",
+				"vehicle_lat": "42.37437",
+				"vehicle_lon": "-71.0302",
+				"vehicle_bearing": "225",
+				"vehicle_timestamp": "1443105649"
+			},
+			"stop": [{
+				"stop_sequence": "70",
+				"stop_id": "70045",
+				"stop_name": "Maverick - Inbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105815",
+				"pre_away": "122"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70043",
+				"stop_name": "Aquarium - Inbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443105984",
+				"pre_away": "291"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70041",
+				"stop_name": "State Street - to Bowdoin",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106083",
+				"pre_away": "390"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106260",
+				"pre_away": "567"
+			}]
+		}, {
+			"trip_id": "28187645",
+			"trip_name": "10:35 am from Wonderland to Bowdoin",
+			"trip_headsign": "Bowdoin",
+			"vehicle": {
+				"vehicle_id": "0752",
+				"vehicle_lat": "42.39043",
+				"vehicle_lon": "-70.99727",
+				"vehicle_bearing": "220",
+				"vehicle_timestamp": "1443105640"
+			},
+			"stop": [{
+				"stop_sequence": "40",
+				"stop_id": "70051",
+				"stop_name": "Orient Heights - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105730",
+				"pre_away": "37"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70049",
+				"stop_name": "Wood Island - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443105914",
+				"pre_away": "221"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70047",
+				"stop_name": "Airport - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106013",
+				"pre_away": "320"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70045",
+				"stop_name": "Maverick - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106179",
+				"pre_away": "486"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70043",
+				"stop_name": "Aquarium - Inbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106348",
+				"pre_away": "655"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70041",
+				"stop_name": "State Street - to Bowdoin",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106447",
+				"pre_away": "754"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443106500",
+				"sch_dep_dt": "1443106500",
+				"pre_dt": "1443106624",
+				"pre_away": "931"
+			}]
+		}, {
+			"trip_id": "28187706",
+			"trip_name": "10:44 am from Wonderland to Bowdoin",
+			"trip_headsign": "Bowdoin",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106140",
+				"pre_away": "447"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70057",
+				"stop_name": "Revere Beach - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106176",
+				"pre_away": "483"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70055",
+				"stop_name": "Beachmont - Inbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106286",
+				"pre_away": "593"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70053",
+				"stop_name": "Suffolk Downs - Inbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106372",
+				"pre_away": "679"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70051",
+				"stop_name": "Orient Heights - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106462",
+				"pre_away": "769"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70049",
+				"stop_name": "Wood Island - Inbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106646",
+				"pre_away": "953"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70047",
+				"stop_name": "Airport - Inbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106745",
+				"pre_away": "1052"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70045",
+				"stop_name": "Maverick - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106911",
+				"pre_away": "1218"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70043",
+				"stop_name": "Aquarium - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443107080",
+				"pre_away": "1387"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70041",
+				"stop_name": "State Street - to Bowdoin",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107179",
+				"pre_away": "1486"
+			}]
+		}, {
+			"trip_id": "28187745",
+			"trip_name": "10:52 am from Wonderland to Bowdoin",
+			"trip_headsign": "Bowdoin",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106759",
+				"pre_away": "1066"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70057",
+				"stop_name": "Revere Beach - Inbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106795",
+				"pre_away": "1102"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70055",
+				"stop_name": "Beachmont - Inbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106905",
+				"pre_away": "1212"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70053",
+				"stop_name": "Suffolk Downs - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106990",
+				"pre_away": "1297"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70051",
+				"stop_name": "Orient Heights - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443107080",
+				"pre_away": "1387"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70049",
+				"stop_name": "Wood Island - Inbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107264",
+				"pre_away": "1571"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70047",
+				"stop_name": "Airport - Inbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107363",
+				"pre_away": "1670"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70045",
+				"stop_name": "Maverick - Inbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107529",
+				"pre_away": "1836"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70043",
+				"stop_name": "Aquarium - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107698",
+				"pre_away": "2005"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70041",
+				"stop_name": "State Street - to Bowdoin",
+				"sch_arr_dt": "1443107220",
+				"sch_dep_dt": "1443107220",
+				"pre_dt": "1443107797",
+				"pre_away": "2104"
+			}]
+		}]
+	}, {
+		"direction_id": "1",
+		"direction_name": "Eastbound",
+		"trip": [{
+			"trip_id": "28187744",
+			"trip_name": "10:23 am from Bowdoin to Wonderland",
+			"trip_headsign": "Wonderland",
+			"vehicle": {
+				"vehicle_id": "0755",
+				"vehicle_lat": "42.37185",
+				"vehicle_lon": "-71.03648",
+				"vehicle_bearing": "45",
+				"vehicle_timestamp": "1443105669"
+			},
+			"stop": [{
+				"stop_sequence": "50",
+				"stop_id": "70048",
+				"stop_name": "Airport - Outbound",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443105729",
+				"pre_away": "36"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70050",
+				"stop_name": "Wood Island - Outbound",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443105833",
+				"pre_away": "140"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70052",
+				"stop_name": "Orient Heights - Outbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443106086",
+				"pre_away": "393"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70054",
+				"stop_name": "Suffolk Downs - Outbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443106178",
+				"pre_away": "485"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70056",
+				"stop_name": "Beachmont - Outbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443106267",
+				"pre_away": "574"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70058",
+				"stop_name": "Revere Beach - Outbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106382",
+				"pre_away": "689"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106484",
+				"pre_away": "791"
+			}]
+		}, {
+			"trip_id": "28187776",
+			"trip_name": "10:32 am from Bowdoin to Wonderland",
+			"trip_headsign": "Wonderland",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443105824",
+				"pre_away": "131"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70042",
+				"stop_name": "State Street - to Wonderland",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443105903",
+				"pre_away": "210"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70044",
+				"stop_name": "Aquarium - Outbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443105994",
+				"pre_away": "301"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70046",
+				"stop_name": "Maverick - Outbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443106148",
+				"pre_away": "455"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70048",
+				"stop_name": "Airport - Outbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443106283",
+				"pre_away": "590"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70050",
+				"stop_name": "Wood Island - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106387",
+				"pre_away": "694"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70052",
+				"stop_name": "Orient Heights - Outbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106640",
+				"pre_away": "947"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70054",
+				"stop_name": "Suffolk Downs - Outbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106732",
+				"pre_away": "1039"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70056",
+				"stop_name": "Beachmont - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106821",
+				"pre_away": "1128"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70058",
+				"stop_name": "Revere Beach - Outbound",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106936",
+				"pre_away": "1243"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443107038",
+				"pre_away": "1345"
+			}]
+		}, {
+			"trip_id": "28187837",
+			"trip_name": "10:41 am from Bowdoin to Wonderland",
+			"trip_headsign": "Wonderland",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105952",
+				"pre_away": "259"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70042",
+				"stop_name": "State Street - to Wonderland",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106031",
+				"pre_away": "338"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70044",
+				"stop_name": "Aquarium - Outbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106122",
+				"pre_away": "429"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70046",
+				"stop_name": "Maverick - Outbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106276",
+				"pre_away": "583"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70048",
+				"stop_name": "Airport - Outbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106411",
+				"pre_away": "718"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70050",
+				"stop_name": "Wood Island - Outbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106515",
+				"pre_away": "822"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70052",
+				"stop_name": "Orient Heights - Outbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106768",
+				"pre_away": "1075"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70054",
+				"stop_name": "Suffolk Downs - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106860",
+				"pre_away": "1167"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70056",
+				"stop_name": "Beachmont - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106949",
+				"pre_away": "1256"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70058",
+				"stop_name": "Revere Beach - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107064",
+				"pre_away": "1371"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107166",
+				"pre_away": "1473"
+			}]
+		}, {
+			"trip_id": "28187932",
+			"trip_name": "10:49 am from Bowdoin to Wonderland",
+			"trip_headsign": "Wonderland",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106418",
+				"pre_away": "725"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70042",
+				"stop_name": "State Street - to Wonderland",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106497",
+				"pre_away": "804"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70044",
+				"stop_name": "Aquarium - Outbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106588",
+				"pre_away": "895"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70046",
+				"stop_name": "Maverick - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106742",
+				"pre_away": "1049"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70048",
+				"stop_name": "Airport - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106877",
+				"pre_away": "1184"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70050",
+				"stop_name": "Wood Island - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443106981",
+				"pre_away": "1288"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70052",
+				"stop_name": "Orient Heights - Outbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107234",
+				"pre_away": "1541"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70054",
+				"stop_name": "Suffolk Downs - Outbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107326",
+				"pre_away": "1633"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70056",
+				"stop_name": "Beachmont - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107415",
+				"pre_away": "1722"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70058",
+				"stop_name": "Revere Beach - Outbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107530",
+				"pre_away": "1837"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443107632",
+				"pre_away": "1939"
+			}]
+		}, {
+			"trip_id": "28187646",
+			"trip_name": "10:58 am from Bowdoin to Wonderland",
+			"trip_headsign": "Wonderland",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70038",
+				"stop_name": "Bowdoin",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106782",
+				"pre_away": "1089"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70042",
+				"stop_name": "State Street - to Wonderland",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443106861",
+				"pre_away": "1168"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70044",
+				"stop_name": "Aquarium - Outbound",
+				"sch_arr_dt": "1443106980",
+				"sch_dep_dt": "1443106980",
+				"pre_dt": "1443106952",
+				"pre_away": "1259"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70046",
+				"stop_name": "Maverick - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107106",
+				"pre_away": "1413"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70048",
+				"stop_name": "Airport - Outbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107241",
+				"pre_away": "1548"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70050",
+				"stop_name": "Wood Island - Outbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443107345",
+				"pre_away": "1652"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70052",
+				"stop_name": "Orient Heights - Outbound",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443107598",
+				"pre_away": "1905"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70054",
+				"stop_name": "Suffolk Downs - Outbound",
+				"sch_arr_dt": "1443107640",
+				"sch_dep_dt": "1443107640",
+				"pre_dt": "1443107690",
+				"pre_away": "1997"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70056",
+				"stop_name": "Beachmont - Outbound",
+				"sch_arr_dt": "1443107760",
+				"sch_dep_dt": "1443107760",
+				"pre_dt": "1443107779",
+				"pre_away": "2086"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70058",
+				"stop_name": "Revere Beach - Outbound",
+				"sch_arr_dt": "1443107880",
+				"sch_dep_dt": "1443107880",
+				"pre_dt": "1443107894",
+				"pre_away": "2201"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70060",
+				"stop_name": "Wonderland",
+				"sch_arr_dt": "1443108000",
+				"sch_dep_dt": "1443108000",
+				"pre_dt": "1443107996",
+				"pre_away": "2303"
+			}]
+		}]
+	}],
+	"alert_headers": []
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/predictions-orange.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/predictions-orange.fixture
@@ -1,0 +1,2103 @@
+GET /developer/api/v2/predictionsbyroute?route=Orange&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:36 GMT
+connection: close
+content-length: 45213
+
+{
+	"route_id": "Orange",
+	"route_name": "Orange Line",
+	"route_type": "1",
+	"mode_name": "Subway",
+	"direction": [{
+		"direction_id": "0",
+		"direction_name": "Southbound",
+		"trip": [{
+			"trip_id": "28190322",
+			"trip_name": "10:05 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1301",
+				"vehicle_lat": "42.3215",
+				"vehicle_lon": "-71.10114",
+				"vehicle_bearing": "210",
+				"vehicle_timestamp": "1443105650"
+			},
+			"stop": [{
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443105300",
+				"sch_dep_dt": "1443105300",
+				"pre_dt": "1443105715",
+				"pre_away": "22"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105808",
+				"pre_away": "115"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105947",
+				"pre_away": "254"
+			}]
+		}, {
+			"trip_id": "28190335",
+			"trip_name": "10:11 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1280",
+				"vehicle_lat": "42.34367",
+				"vehicle_lon": "-71.08084",
+				"vehicle_bearing": "220",
+				"vehicle_timestamp": "1443105659"
+			},
+			"stop": [{
+				"stop_sequence": "130",
+				"stop_id": "70012",
+				"stop_name": "Massachusetts Avenue - Outbound",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443105688",
+				"pre_away": "4"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443105779",
+				"pre_away": "86"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105880",
+				"pre_away": "187"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443105974",
+				"pre_away": "281"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443106084",
+				"pre_away": "391"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106177",
+				"pre_away": "484"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106316",
+				"pre_away": "623"
+			}]
+		}, {
+			"trip_id": "28190349",
+			"trip_name": "10:17 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1203",
+				"vehicle_lat": "42.34767",
+				"vehicle_lon": "-71.07464",
+				"vehicle_bearing": "265",
+				"vehicle_timestamp": "1443105661"
+			},
+			"stop": [{
+				"stop_sequence": "130",
+				"stop_id": "70012",
+				"stop_name": "Massachusetts Avenue - Outbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443105800",
+				"pre_away": "107"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443105891",
+				"pre_away": "198"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443105992",
+				"pre_away": "299"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106086",
+				"pre_away": "393"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106196",
+				"pre_away": "503"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106289",
+				"pre_away": "596"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106428",
+				"pre_away": "735"
+			}]
+		}, {
+			"trip_id": "28190359",
+			"trip_name": "10:24 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1286",
+				"vehicle_lat": "42.36912",
+				"vehicle_lon": "-71.06371",
+				"vehicle_bearing": "150",
+				"vehicle_timestamp": "1443105656"
+			},
+			"stop": [{
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443105697",
+				"pre_away": "4"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105779",
+				"pre_away": "86"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105869",
+				"pre_away": "176"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443105939",
+				"pre_away": "246"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106027",
+				"pre_away": "334"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70016",
+				"stop_name": "Tufts Medical Center - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106096",
+				"pre_away": "403"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70014",
+				"stop_name": "Back Bay - Outbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106214",
+				"pre_away": "521"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70012",
+				"stop_name": "Massachusetts Avenue - Outbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106352",
+				"pre_away": "659"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106443",
+				"pre_away": "750"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106544",
+				"pre_away": "851"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106638",
+				"pre_away": "945"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106748",
+				"pre_away": "1055"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106841",
+				"pre_away": "1148"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106980",
+				"pre_away": "1287"
+			}]
+		}, {
+			"trip_id": "28190236",
+			"trip_name": "10:31 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1293",
+				"vehicle_lat": "42.39053",
+				"vehicle_lon": "-71.07708",
+				"vehicle_bearing": "175",
+				"vehicle_timestamp": "1443105666"
+			},
+			"stop": [{
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105756",
+				"pre_away": "63"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105891",
+				"pre_away": "198"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106024",
+				"pre_away": "331"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106106",
+				"pre_away": "413"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106196",
+				"pre_away": "503"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106266",
+				"pre_away": "573"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106354",
+				"pre_away": "661"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70016",
+				"stop_name": "Tufts Medical Center - Outbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106423",
+				"pre_away": "730"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70014",
+				"stop_name": "Back Bay - Outbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106541",
+				"pre_away": "848"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70012",
+				"stop_name": "Massachusetts Avenue - Outbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106680",
+				"pre_away": "987"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106771",
+				"pre_away": "1078"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106872",
+				"pre_away": "1179"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443106966",
+				"pre_away": "1273"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443107076",
+				"pre_away": "1383"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443106980",
+				"sch_dep_dt": "1443106980",
+				"pre_dt": "1443107169",
+				"pre_away": "1476"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443107100",
+				"sch_dep_dt": "1443107100",
+				"pre_dt": "1443107308",
+				"pre_away": "1615"
+			}]
+		}, {
+			"trip_id": "28190248",
+			"trip_name": "10:39 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"vehicle": {
+				"vehicle_id": "1235",
+				"vehicle_lat": "42.43223",
+				"vehicle_lon": "-71.07213",
+				"vehicle_bearing": "200",
+				"vehicle_timestamp": "1443105624"
+			},
+			"stop": [{
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105690",
+				"pre_away": "2"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443105909",
+				"pre_away": "216"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106086",
+				"pre_away": "393"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106244",
+				"pre_away": "551"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106379",
+				"pre_away": "686"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106513",
+				"pre_away": "820"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106595",
+				"pre_away": "902"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106685",
+				"pre_away": "992"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443106500",
+				"sch_dep_dt": "1443106500",
+				"pre_dt": "1443106755",
+				"pre_away": "1062"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443106620",
+				"sch_dep_dt": "1443106620",
+				"pre_dt": "1443106843",
+				"pre_away": "1150"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70016",
+				"stop_name": "Tufts Medical Center - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106912",
+				"pre_away": "1219"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70014",
+				"stop_name": "Back Bay - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107031",
+				"pre_away": "1338"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70012",
+				"stop_name": "Massachusetts Avenue - Outbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107169",
+				"pre_away": "1476"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70010",
+				"stop_name": "Ruggles - Outbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107260",
+				"pre_away": "1567"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70008",
+				"stop_name": "Roxbury Crossing - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107361",
+				"pre_away": "1668"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70006",
+				"stop_name": "Jackson Square - Outbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107455",
+				"pre_away": "1762"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70004",
+				"stop_name": "Stony Brook - Outbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443107565",
+				"pre_away": "1872"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70002",
+				"stop_name": "Green Street - Outbound",
+				"sch_arr_dt": "1443107460",
+				"sch_dep_dt": "1443107460",
+				"pre_dt": "1443107658",
+				"pre_away": "1965"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443107797",
+				"pre_away": "2104"
+			}]
+		}, {
+			"trip_id": "28190272",
+			"trip_name": "10:48 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106080",
+				"pre_away": "387"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106187",
+				"pre_away": "494"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106406",
+				"pre_away": "713"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106580",
+				"pre_away": "887"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106751",
+				"pre_away": "1058"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106886",
+				"pre_away": "1193"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107020",
+				"pre_away": "1327"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443107102",
+				"pre_away": "1409"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107193",
+				"pre_away": "1500"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107264",
+				"pre_away": "1571"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107352",
+				"pre_away": "1659"
+			}]
+		}, {
+			"trip_id": "28190293",
+			"trip_name": "10:56 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106560",
+				"pre_away": "867"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106667",
+				"pre_away": "974"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443106886",
+				"pre_away": "1193"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443107063",
+				"pre_away": "1370"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107221",
+				"pre_away": "1528"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107356",
+				"pre_away": "1663"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107490",
+				"pre_away": "1797"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443107572",
+				"pre_away": "1879"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443107662",
+				"pre_away": "1969"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443107732",
+				"pre_away": "2039"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443107640",
+				"sch_dep_dt": "1443107640",
+				"pre_dt": "1443107820",
+				"pre_away": "2127"
+			}]
+		}, {
+			"trip_id": "28190298",
+			"trip_name": "11:04 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107569",
+				"pre_away": "1876"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107676",
+				"pre_away": "1983"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443107895",
+				"pre_away": "2202"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443108072",
+				"pre_away": "2379"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443108230",
+				"pre_away": "2537"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443107640",
+				"sch_dep_dt": "1443107640",
+				"pre_dt": "1443108365",
+				"pre_away": "2672"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443107760",
+				"sch_dep_dt": "1443107760",
+				"pre_dt": "1443108498",
+				"pre_away": "2805"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443107820",
+				"sch_dep_dt": "1443107820",
+				"pre_dt": "1443108580",
+				"pre_away": "2887"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443107880",
+				"sch_dep_dt": "1443107880",
+				"pre_dt": "1443108670",
+				"pre_away": "2977"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443108000",
+				"sch_dep_dt": "1443108000",
+				"pre_dt": "1443108740",
+				"pre_away": "3047"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443108120",
+				"sch_dep_dt": "1443108120",
+				"pre_dt": "1443108828",
+				"pre_away": "3135"
+			}]
+		}, {
+			"trip_id": "28190310",
+			"trip_name": "11:13 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443107912",
+				"pre_away": "2219"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443107700",
+				"sch_dep_dt": "1443107700",
+				"pre_dt": "1443108019",
+				"pre_away": "2326"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443107880",
+				"sch_dep_dt": "1443107880",
+				"pre_dt": "1443108238",
+				"pre_away": "2545"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443107940",
+				"sch_dep_dt": "1443107940",
+				"pre_dt": "1443108415",
+				"pre_away": "2722"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443108060",
+				"sch_dep_dt": "1443108060",
+				"pre_dt": "1443108573",
+				"pre_away": "2880"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443108180",
+				"sch_dep_dt": "1443108180",
+				"pre_dt": "1443108708",
+				"pre_away": "3015"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443108300",
+				"sch_dep_dt": "1443108300",
+				"pre_dt": "1443108841",
+				"pre_away": "3148"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443108360",
+				"sch_dep_dt": "1443108360",
+				"pre_dt": "1443108923",
+				"pre_away": "3230"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443108420",
+				"sch_dep_dt": "1443108420",
+				"pre_dt": "1443109013",
+				"pre_away": "3320"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443108540",
+				"sch_dep_dt": "1443108540",
+				"pre_dt": "1443109083",
+				"pre_away": "3390"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443108660",
+				"sch_dep_dt": "1443108660",
+				"pre_dt": "1443109171",
+				"pre_away": "3478"
+			}]
+		}, {
+			"trip_id": "28190324",
+			"trip_name": "11:21 am from Oak Grove to Forest Hills Orange Line",
+			"trip_headsign": "Forest Hills",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443108060",
+				"sch_dep_dt": "1443108060",
+				"pre_dt": "1443108146",
+				"pre_away": "2453"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70034",
+				"stop_name": "Malden - Inbound",
+				"sch_arr_dt": "1443108180",
+				"sch_dep_dt": "1443108180",
+				"pre_dt": "1443108253",
+				"pre_away": "2560"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70032",
+				"stop_name": "Wellington - Inbound",
+				"sch_arr_dt": "1443108360",
+				"sch_dep_dt": "1443108360",
+				"pre_dt": "1443108472",
+				"pre_away": "2779"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70278",
+				"stop_name": "Assembly - Inbound",
+				"sch_arr_dt": "1443108420",
+				"sch_dep_dt": "1443108420",
+				"pre_dt": "1443108649",
+				"pre_away": "2956"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70030",
+				"stop_name": "Sullivan Square - Inbound",
+				"sch_arr_dt": "1443108540",
+				"sch_dep_dt": "1443108540",
+				"pre_dt": "1443108807",
+				"pre_away": "3114"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70028",
+				"stop_name": "Community College - Inbound",
+				"sch_arr_dt": "1443108660",
+				"sch_dep_dt": "1443108660",
+				"pre_dt": "1443108942",
+				"pre_away": "3249"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70026",
+				"stop_name": "North Station - Orange Line Inbound",
+				"sch_arr_dt": "1443108780",
+				"sch_dep_dt": "1443108780",
+				"pre_dt": "1443109076",
+				"pre_away": "3383"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70024",
+				"stop_name": "Haymarket - Orange Line Inbound",
+				"sch_arr_dt": "1443108840",
+				"sch_dep_dt": "1443108840",
+				"pre_dt": "1443109158",
+				"pre_away": "3465"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70022",
+				"stop_name": "State Street - to Forest Hills",
+				"sch_arr_dt": "1443108900",
+				"sch_dep_dt": "1443108900",
+				"pre_dt": "1443109248",
+				"pre_away": "3555"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70020",
+				"stop_name": "Downtown Crossing - to Forest Hills",
+				"sch_arr_dt": "1443109020",
+				"sch_dep_dt": "1443109020",
+				"pre_dt": "1443109318",
+				"pre_away": "3625"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70018",
+				"stop_name": "Chinatown - Outbound",
+				"sch_arr_dt": "1443109140",
+				"sch_dep_dt": "1443109140",
+				"pre_dt": "1443109406",
+				"pre_away": "3713"
+			}]
+		}]
+	}, {
+		"direction_id": "1",
+		"direction_name": "Northbound",
+		"trip": [{
+			"trip_id": "28190525",
+			"trip_name": "10:02 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1206",
+				"vehicle_lat": "42.42669",
+				"vehicle_lon": "-71.07428",
+				"vehicle_bearing": "20",
+				"vehicle_timestamp": "1443105627"
+			},
+			"stop": [{
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105816",
+				"pre_away": "123"
+			}]
+		}, {
+			"trip_id": "28190476",
+			"trip_name": "10:09 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1214",
+				"vehicle_lat": "42.3925",
+				"vehicle_lon": "-71.07715",
+				"vehicle_bearing": "355",
+				"vehicle_timestamp": "1443105626"
+			},
+			"stop": [{
+				"stop_sequence": "170",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105788",
+				"pre_away": "95"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106026",
+				"pre_away": "333"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106215",
+				"pre_away": "522"
+			}]
+		}, {
+			"trip_id": "28190494",
+			"trip_name": "10:16 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1221",
+				"vehicle_lat": "42.35656",
+				"vehicle_lon": "-71.0592",
+				"vehicle_bearing": "30",
+				"vehicle_timestamp": "1443105664"
+			},
+			"stop": [{
+				"stop_sequence": "110",
+				"stop_id": "70023",
+				"stop_name": "State Street - to Oak Grove",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105688",
+				"pre_away": "4"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70025",
+				"stop_name": "Haymarket - Orange Line Outbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105768",
+				"pre_away": "75"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70027",
+				"stop_name": "North Station - Orange Line Outbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105851",
+				"pre_away": "158"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70029",
+				"stop_name": "Community College - Outbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105994",
+				"pre_away": "301"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70031",
+				"stop_name": "Sullivan Square - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106153",
+				"pre_away": "460"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70279",
+				"stop_name": "Assembly - Outbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106266",
+				"pre_away": "573"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106428",
+				"pre_away": "735"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106666",
+				"pre_away": "973"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106855",
+				"pre_away": "1162"
+			}]
+		}, {
+			"trip_id": "28190303",
+			"trip_name": "10:23 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1216",
+				"vehicle_lat": "42.33951",
+				"vehicle_lon": "-71.08571",
+				"vehicle_bearing": "40",
+				"vehicle_timestamp": "1443105658"
+			},
+			"stop": [{
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443105300",
+				"sch_dep_dt": "1443105300",
+				"pre_dt": "1443105672",
+				"pre_away": "20"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105802",
+				"pre_away": "109"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105933",
+				"pre_away": "240"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443106024",
+				"pre_away": "331"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70021",
+				"stop_name": "Downtown Crossing - to Oak Grove",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106102",
+				"pre_away": "409"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70023",
+				"stop_name": "State Street - to Oak Grove",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106205",
+				"pre_away": "512"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70025",
+				"stop_name": "Haymarket - Orange Line Outbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106285",
+				"pre_away": "592"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70027",
+				"stop_name": "North Station - Orange Line Outbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106368",
+				"pre_away": "675"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70029",
+				"stop_name": "Community College - Outbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106511",
+				"pre_away": "818"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70031",
+				"stop_name": "Sullivan Square - Outbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106670",
+				"pre_away": "977"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70279",
+				"stop_name": "Assembly - Outbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106783",
+				"pre_away": "1090"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106945",
+				"pre_away": "1252"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443107183",
+				"pre_away": "1490"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443107372",
+				"pre_away": "1679"
+			}]
+		}, {
+			"trip_id": "28190309",
+			"trip_name": "10:31 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1219",
+				"vehicle_lat": "42.32077",
+				"vehicle_lon": "-71.10166",
+				"vehicle_bearing": "30",
+				"vehicle_timestamp": "1443105669"
+			},
+			"stop": [{
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443105694",
+				"pre_away": "1"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105809",
+				"pre_away": "116"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105904",
+				"pre_away": "211"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106013",
+				"pre_away": "320"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106143",
+				"pre_away": "450"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106274",
+				"pre_away": "581"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106365",
+				"pre_away": "672"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70021",
+				"stop_name": "Downtown Crossing - to Oak Grove",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106443",
+				"pre_away": "750"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70023",
+				"stop_name": "State Street - to Oak Grove",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106548",
+				"pre_away": "855"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70025",
+				"stop_name": "Haymarket - Orange Line Outbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106628",
+				"pre_away": "935"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70027",
+				"stop_name": "North Station - Orange Line Outbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106711",
+				"pre_away": "1018"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70029",
+				"stop_name": "Community College - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106854",
+				"pre_away": "1161"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70031",
+				"stop_name": "Sullivan Square - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443107013",
+				"pre_away": "1320"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70279",
+				"stop_name": "Assembly - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107126",
+				"pre_away": "1433"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443107288",
+				"pre_away": "1595"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107526",
+				"pre_away": "1833"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107715",
+				"pre_away": "2022"
+			}]
+		}, {
+			"trip_id": "28190323",
+			"trip_name": "10:39 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"vehicle": {
+				"vehicle_id": "1257",
+				"vehicle_lat": "42.3029",
+				"vehicle_lon": "-71.11259",
+				"vehicle_bearing": "30",
+				"vehicle_timestamp": "1443105651"
+			},
+			"stop": [{
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105721",
+				"pre_away": "28"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443105819",
+				"pre_away": "126"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443105930",
+				"pre_away": "237"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106045",
+				"pre_away": "352"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106140",
+				"pre_away": "447"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443106249",
+				"pre_away": "556"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106379",
+				"pre_away": "686"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443106500",
+				"sch_dep_dt": "1443106500",
+				"pre_dt": "1443106510",
+				"pre_away": "817"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106601",
+				"pre_away": "908"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70021",
+				"stop_name": "Downtown Crossing - to Oak Grove",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106679",
+				"pre_away": "986"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70023",
+				"stop_name": "State Street - to Oak Grove",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443106782",
+				"pre_away": "1089"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70025",
+				"stop_name": "Haymarket - Orange Line Outbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443106862",
+				"pre_away": "1169"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70027",
+				"stop_name": "North Station - Orange Line Outbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443106945",
+				"pre_away": "1252"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70029",
+				"stop_name": "Community College - Outbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107088",
+				"pre_away": "1395"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70031",
+				"stop_name": "Sullivan Square - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107247",
+				"pre_away": "1554"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70279",
+				"stop_name": "Assembly - Outbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107360",
+				"pre_away": "1667"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70033",
+				"stop_name": "Wellington - Outbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443107522",
+				"pre_away": "1829"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70035",
+				"stop_name": "Malden - Outbound",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443107760",
+				"pre_away": "2067"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70036",
+				"stop_name": "Oak Grove",
+				"sch_arr_dt": "1443107640",
+				"sch_dep_dt": "1443107640",
+				"pre_dt": "1443107949",
+				"pre_away": "2256"
+			}]
+		}, {
+			"trip_id": "28190336",
+			"trip_name": "10:48 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106111",
+				"pre_away": "418"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106204",
+				"pre_away": "511"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106302",
+				"pre_away": "609"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106413",
+				"pre_away": "720"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106528",
+				"pre_away": "835"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106623",
+				"pre_away": "930"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443106732",
+				"pre_away": "1039"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443106862",
+				"pre_away": "1169"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443106993",
+				"pre_away": "1300"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443107100",
+				"sch_dep_dt": "1443107100",
+				"pre_dt": "1443107084",
+				"pre_away": "1391"
+			}]
+		}, {
+			"trip_id": "28190350",
+			"trip_name": "10:56 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106560",
+				"pre_away": "867"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443106653",
+				"pre_away": "960"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443106751",
+				"pre_away": "1058"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443106862",
+				"pre_away": "1169"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443106977",
+				"pre_away": "1284"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107072",
+				"pre_away": "1379"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107181",
+				"pre_away": "1488"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443107311",
+				"pre_away": "1618"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443107442",
+				"pre_away": "1749"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443107533",
+				"pre_away": "1840"
+			}]
+		}, {
+			"trip_id": "28190360",
+			"trip_name": "11:04 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443107144",
+				"pre_away": "1451"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443107237",
+				"pre_away": "1544"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443107335",
+				"pre_away": "1642"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443107446",
+				"pre_away": "1753"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443107561",
+				"pre_away": "1868"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443107640",
+				"sch_dep_dt": "1443107640",
+				"pre_dt": "1443107656",
+				"pre_away": "1963"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443107760",
+				"sch_dep_dt": "1443107760",
+				"pre_dt": "1443107765",
+				"pre_away": "2072"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443107880",
+				"sch_dep_dt": "1443107880",
+				"pre_dt": "1443107895",
+				"pre_away": "2202"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443108000",
+				"sch_dep_dt": "1443108000",
+				"pre_dt": "1443108026",
+				"pre_away": "2333"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443108060",
+				"sch_dep_dt": "1443108060",
+				"pre_dt": "1443108117",
+				"pre_away": "2424"
+			}]
+		}, {
+			"trip_id": "28190237",
+			"trip_name": "11:13 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443107580",
+				"pre_away": "1887"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443107700",
+				"sch_dep_dt": "1443107700",
+				"pre_dt": "1443107673",
+				"pre_away": "1980"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443107820",
+				"sch_dep_dt": "1443107820",
+				"pre_dt": "1443107771",
+				"pre_away": "2078"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443107940",
+				"sch_dep_dt": "1443107940",
+				"pre_dt": "1443107882",
+				"pre_away": "2189"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443108060",
+				"sch_dep_dt": "1443108060",
+				"pre_dt": "1443107997",
+				"pre_away": "2304"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443108180",
+				"sch_dep_dt": "1443108180",
+				"pre_dt": "1443108092",
+				"pre_away": "2399"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443108300",
+				"sch_dep_dt": "1443108300",
+				"pre_dt": "1443108201",
+				"pre_away": "2508"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443108420",
+				"sch_dep_dt": "1443108420",
+				"pre_dt": "1443108331",
+				"pre_away": "2638"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443108540",
+				"sch_dep_dt": "1443108540",
+				"pre_dt": "1443108462",
+				"pre_away": "2769"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443108600",
+				"sch_dep_dt": "1443108600",
+				"pre_dt": "1443108553",
+				"pre_away": "2860"
+			}]
+		}, {
+			"trip_id": "28190249",
+			"trip_name": "11:21 am from Forest Hills Orange Line to Oak Grove",
+			"trip_headsign": "Oak Grove",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70001",
+				"stop_name": "Forest Hills Orange Line",
+				"sch_arr_dt": "1443108060",
+				"sch_dep_dt": "1443108060",
+				"pre_dt": "1443108060",
+				"pre_away": "2367"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70003",
+				"stop_name": "Green Street - Inbound",
+				"sch_arr_dt": "1443108180",
+				"sch_dep_dt": "1443108180",
+				"pre_dt": "1443108153",
+				"pre_away": "2460"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70005",
+				"stop_name": "Stony Brook - Inbound",
+				"sch_arr_dt": "1443108300",
+				"sch_dep_dt": "1443108300",
+				"pre_dt": "1443108251",
+				"pre_away": "2558"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70007",
+				"stop_name": "Jackson Square - Inbound",
+				"sch_arr_dt": "1443108420",
+				"sch_dep_dt": "1443108420",
+				"pre_dt": "1443108365",
+				"pre_away": "2672"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70009",
+				"stop_name": "Roxbury Crossing - Inbound",
+				"sch_arr_dt": "1443108540",
+				"sch_dep_dt": "1443108540",
+				"pre_dt": "1443108480",
+				"pre_away": "2787"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70011",
+				"stop_name": "Ruggles - Inbound",
+				"sch_arr_dt": "1443108660",
+				"sch_dep_dt": "1443108660",
+				"pre_dt": "1443108575",
+				"pre_away": "2882"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70013",
+				"stop_name": "Massachusetts Avenue - Inbound",
+				"sch_arr_dt": "1443108780",
+				"sch_dep_dt": "1443108780",
+				"pre_dt": "1443108684",
+				"pre_away": "2991"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70015",
+				"stop_name": "Back Bay - Inbound",
+				"sch_arr_dt": "1443108900",
+				"sch_dep_dt": "1443108900",
+				"pre_dt": "1443108814",
+				"pre_away": "3121"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70017",
+				"stop_name": "Tufts Medical Center - Inbound",
+				"sch_arr_dt": "1443109020",
+				"sch_dep_dt": "1443109020",
+				"pre_dt": "1443108945",
+				"pre_away": "3252"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70019",
+				"stop_name": "Chinatown - Inbound",
+				"sch_arr_dt": "1443109080",
+				"sch_dep_dt": "1443109080",
+				"pre_dt": "1443109036",
+				"pre_away": "3343"
+			}]
+		}]
+	}],
+	"alert_headers": [{
+		"alert_id": 88088,
+		"header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+		"effect_name": "Station Issue"
+	}]
+}

--- a/fixtures/red-line-delay/realtime.mbta.com/predictions-red.fixture
+++ b/fixtures/red-line-delay/realtime.mbta.com/predictions-red.fixture
@@ -1,0 +1,2664 @@
+GET /developer/api/v2/predictionsbyroute?route=Red&api_key=wX9NwuHnZU2ToO7GmGR9uw&format=json
+accept: */*
+host: realtime.mbta.com
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+cache-control: no-cache
+pragma: no-cache
+content-type: application/json; charset=utf-8
+expires: -1
+server: Microsoft-IIS/7.5
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 24 Sep 2015 14:41:28 GMT
+connection: close
+content-length: 55307
+
+{
+	"route_id": "Red",
+	"route_name": "Red Line",
+	"route_type": "1",
+	"mode_name": "Subway",
+	"direction": [{
+		"direction_id": "0",
+		"direction_name": "Southbound",
+		"trip": [{
+			"trip_id": "28192808",
+			"trip_name": "8:16 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"vehicle": {
+				"vehicle_id": "1630",
+				"vehicle_lat": "42.23998",
+				"vehicle_lon": "-71.0054",
+				"vehicle_bearing": "195",
+				"vehicle_timestamp": "1443105648"
+			},
+			"stop": [{
+				"stop_sequence": "210",
+				"stop_id": "70103",
+				"stop_name": "Quincy Adams - Outbound",
+				"sch_arr_dt": "1443099840",
+				"sch_dep_dt": "1443099840",
+				"pre_dt": "1443105700",
+				"pre_away": "23"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443100080",
+				"sch_dep_dt": "1443100080",
+				"pre_dt": "1443105982",
+				"pre_away": "305"
+			}]
+		}, {
+			"trip_id": "28192708",
+			"trip_name": "8:21 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"vehicle": {
+				"vehicle_id": "1613",
+				"vehicle_lat": "42.35954",
+				"vehicle_lon": "-71.06784",
+				"vehicle_bearing": "130",
+				"vehicle_timestamp": "1443105648"
+			},
+			"stop": [{
+				"stop_sequence": "70",
+				"stop_id": "70075",
+				"stop_name": "Park Street - to Ashmont/Braintree",
+				"sch_arr_dt": "1443098400",
+				"sch_dep_dt": "1443098400",
+				"pre_dt": "1443105685",
+				"pre_away": "8"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70077",
+				"stop_name": "Downtown Crossing - to Ashmont/Braintree",
+				"sch_arr_dt": "1443098520",
+				"sch_dep_dt": "1443098520",
+				"pre_dt": "1443105782",
+				"pre_away": "105"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70079",
+				"stop_name": "South Station - Outbound",
+				"sch_arr_dt": "1443098700",
+				"sch_dep_dt": "1443098700",
+				"pre_dt": "1443105877",
+				"pre_away": "200"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70081",
+				"stop_name": "Broadway - Outbound",
+				"sch_arr_dt": "1443098880",
+				"sch_dep_dt": "1443098880",
+				"pre_dt": "1443106025",
+				"pre_away": "348"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70083",
+				"stop_name": "Andrew - Outbound",
+				"sch_arr_dt": "1443099000",
+				"sch_dep_dt": "1443099000",
+				"pre_dt": "1443106150",
+				"pre_away": "473"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70085",
+				"stop_name": "JFK/UMASS Ashmont - Outbound",
+				"sch_arr_dt": "1443099120",
+				"sch_dep_dt": "1443099120",
+				"pre_dt": "1443106334",
+				"pre_away": "657"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70087",
+				"stop_name": "Savin Hill - Outbound",
+				"sch_arr_dt": "1443099300",
+				"sch_dep_dt": "1443099300",
+				"pre_dt": "1443106483",
+				"pre_away": "806"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70089",
+				"stop_name": "Fields Corner - Outbound",
+				"sch_arr_dt": "1443099480",
+				"sch_dep_dt": "1443099480",
+				"pre_dt": "1443106662",
+				"pre_away": "985"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70091",
+				"stop_name": "Shawmut - Outbound",
+				"sch_arr_dt": "1443099600",
+				"sch_dep_dt": "1443099600",
+				"pre_dt": "1443106807",
+				"pre_away": "1130"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70093",
+				"stop_name": "Ashmont - Outbound",
+				"sch_arr_dt": "1443099780",
+				"sch_dep_dt": "1443099780",
+				"pre_dt": "1443106963",
+				"pre_away": "1286"
+			}]
+		}, {
+			"trip_id": "28192809",
+			"trip_name": "8:25 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"vehicle": {
+				"vehicle_id": "1519",
+				"vehicle_lat": "42.36804",
+				"vehicle_lon": "-71.10831",
+				"vehicle_bearing": "125",
+				"vehicle_timestamp": "1443105642"
+			},
+			"stop": [{
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443098160",
+				"sch_dep_dt": "1443098160",
+				"pre_dt": "1443105665",
+				"pre_away": "11"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443098340",
+				"sch_dep_dt": "1443098340",
+				"pre_dt": "1443105828",
+				"pre_away": "151"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70073",
+				"stop_name": "Charles/MGH - Inbound",
+				"sch_arr_dt": "1443098460",
+				"sch_dep_dt": "1443098460",
+				"pre_dt": "1443105976",
+				"pre_away": "299"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70075",
+				"stop_name": "Park Street - to Ashmont/Braintree",
+				"sch_arr_dt": "1443098640",
+				"sch_dep_dt": "1443098640",
+				"pre_dt": "1443106090",
+				"pre_away": "413"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70077",
+				"stop_name": "Downtown Crossing - to Ashmont/Braintree",
+				"sch_arr_dt": "1443098760",
+				"sch_dep_dt": "1443098760",
+				"pre_dt": "1443106187",
+				"pre_away": "510"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70079",
+				"stop_name": "South Station - Outbound",
+				"sch_arr_dt": "1443098940",
+				"sch_dep_dt": "1443098940",
+				"pre_dt": "1443106282",
+				"pre_away": "605"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70081",
+				"stop_name": "Broadway - Outbound",
+				"sch_arr_dt": "1443099120",
+				"sch_dep_dt": "1443099120",
+				"pre_dt": "1443106430",
+				"pre_away": "753"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70083",
+				"stop_name": "Andrew - Outbound",
+				"sch_arr_dt": "1443099240",
+				"sch_dep_dt": "1443099240",
+				"pre_dt": "1443106555",
+				"pre_away": "878"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70095",
+				"stop_name": "JFK/UMASS Braintree - Outbound",
+				"sch_arr_dt": "1443099360",
+				"sch_dep_dt": "1443099360",
+				"pre_dt": "1443106712",
+				"pre_away": "1035"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70097",
+				"stop_name": "North Quincy - Outbound",
+				"sch_arr_dt": "1443099780",
+				"sch_dep_dt": "1443099780",
+				"pre_dt": "1443107164",
+				"pre_away": "1487"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70099",
+				"stop_name": "Wollaston - Outbound",
+				"sch_arr_dt": "1443099960",
+				"sch_dep_dt": "1443099960",
+				"pre_dt": "1443107284",
+				"pre_away": "1607"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70101",
+				"stop_name": "Quincy Center - Outbound",
+				"sch_arr_dt": "1443100140",
+				"sch_dep_dt": "1443100140",
+				"pre_dt": "1443107464",
+				"pre_away": "1787"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70103",
+				"stop_name": "Quincy Adams - Outbound",
+				"sch_arr_dt": "1443100380",
+				"sch_dep_dt": "1443100380",
+				"pre_dt": "1443107644",
+				"pre_away": "1967"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443100620",
+				"sch_dep_dt": "1443100620",
+				"pre_dt": "1443107926",
+				"pre_away": "2249"
+			}]
+		}, {
+			"trip_id": "28192710",
+			"trip_name": "8:37 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443098220",
+				"sch_dep_dt": "1443098220",
+				"pre_dt": "1443105709",
+				"pre_away": "32"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443098400",
+				"sch_dep_dt": "1443098400",
+				"pre_dt": "1443105821",
+				"pre_away": "144"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443098520",
+				"sch_dep_dt": "1443098520",
+				"pre_dt": "1443105970",
+				"pre_away": "293"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443098700",
+				"sch_dep_dt": "1443098700",
+				"pre_dt": "1443106135",
+				"pre_away": "458"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443098880",
+				"sch_dep_dt": "1443098880",
+				"pre_dt": "1443106346",
+				"pre_away": "669"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443099060",
+				"sch_dep_dt": "1443099060",
+				"pre_dt": "1443106514",
+				"pre_away": "837"
+			}]
+		}, {
+			"trip_id": "28192811",
+			"trip_name": "8:43 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"vehicle": {
+				"vehicle_id": "1877",
+				"vehicle_lat": "42.27576",
+				"vehicle_lon": "-71.03024",
+				"vehicle_bearing": "135",
+				"vehicle_timestamp": "1443105601"
+			},
+			"stop": [{
+				"stop_sequence": "190",
+				"stop_id": "70099",
+				"stop_name": "Wollaston - Outbound",
+				"sch_arr_dt": "1443101040",
+				"sch_dep_dt": "1443101040",
+				"pre_dt": "1443105721",
+				"pre_away": "44"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70101",
+				"stop_name": "Quincy Center - Outbound",
+				"sch_arr_dt": "1443101220",
+				"sch_dep_dt": "1443101220",
+				"pre_dt": "1443105901",
+				"pre_away": "224"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70103",
+				"stop_name": "Quincy Adams - Outbound",
+				"sch_arr_dt": "1443101460",
+				"sch_dep_dt": "1443101460",
+				"pre_dt": "1443106081",
+				"pre_away": "404"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443101700",
+				"sch_dep_dt": "1443101700",
+				"pre_dt": "1443106363",
+				"pre_away": "686"
+			}]
+		}, {
+			"trip_id": "28192812",
+			"trip_name": "8:50 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"vehicle": {
+				"vehicle_id": "1869",
+				"vehicle_lat": "42.34157",
+				"vehicle_lon": "-71.05711",
+				"vehicle_bearing": "175",
+				"vehicle_timestamp": "1443105607"
+			},
+			"stop": [{
+				"stop_sequence": "110",
+				"stop_id": "70083",
+				"stop_name": "Andrew - Outbound",
+				"sch_arr_dt": "1443100740",
+				"sch_dep_dt": "1443100740",
+				"pre_dt": "1443105713",
+				"pre_away": "36"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70095",
+				"stop_name": "JFK/UMASS Braintree - Outbound",
+				"sch_arr_dt": "1443100860",
+				"sch_dep_dt": "1443100860",
+				"pre_dt": "1443105870",
+				"pre_away": "193"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70097",
+				"stop_name": "North Quincy - Outbound",
+				"sch_arr_dt": "1443101280",
+				"sch_dep_dt": "1443101280",
+				"pre_dt": "1443106322",
+				"pre_away": "645"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70099",
+				"stop_name": "Wollaston - Outbound",
+				"sch_arr_dt": "1443101460",
+				"sch_dep_dt": "1443101460",
+				"pre_dt": "1443106442",
+				"pre_away": "765"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70101",
+				"stop_name": "Quincy Center - Outbound",
+				"sch_arr_dt": "1443101640",
+				"sch_dep_dt": "1443101640",
+				"pre_dt": "1443106622",
+				"pre_away": "945"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70103",
+				"stop_name": "Quincy Adams - Outbound",
+				"sch_arr_dt": "1443101880",
+				"sch_dep_dt": "1443101880",
+				"pre_dt": "1443106802",
+				"pre_away": "1125"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443102120",
+				"sch_dep_dt": "1443102120",
+				"pre_dt": "1443107084",
+				"pre_away": "1407"
+			}]
+		}, {
+			"trip_id": "28192813",
+			"trip_name": "8:59 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"vehicle": {
+				"vehicle_id": "1621",
+				"vehicle_lat": "42.39626",
+				"vehicle_lon": "-71.13846",
+				"vehicle_bearing": "85",
+				"vehicle_timestamp": "1443105572"
+			},
+			"stop": [{
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443099720",
+				"sch_dep_dt": "1443099720",
+				"pre_dt": "1443105735",
+				"pre_away": "58"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443099840",
+				"sch_dep_dt": "1443099840",
+				"pre_dt": "1443105868",
+				"pre_away": "191"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443100020",
+				"sch_dep_dt": "1443100020",
+				"pre_dt": "1443106033",
+				"pre_away": "356"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443100200",
+				"sch_dep_dt": "1443100200",
+				"pre_dt": "1443106244",
+				"pre_away": "567"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443100380",
+				"sch_dep_dt": "1443100380",
+				"pre_dt": "1443106407",
+				"pre_away": "730"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70073",
+				"stop_name": "Charles/MGH - Inbound",
+				"sch_arr_dt": "1443100500",
+				"sch_dep_dt": "1443100500",
+				"pre_dt": "1443106555",
+				"pre_away": "878"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70075",
+				"stop_name": "Park Street - to Ashmont/Braintree",
+				"sch_arr_dt": "1443100680",
+				"sch_dep_dt": "1443100680",
+				"pre_dt": "1443106669",
+				"pre_away": "992"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70077",
+				"stop_name": "Downtown Crossing - to Ashmont/Braintree",
+				"sch_arr_dt": "1443100800",
+				"sch_dep_dt": "1443100800",
+				"pre_dt": "1443106766",
+				"pre_away": "1089"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70079",
+				"stop_name": "South Station - Outbound",
+				"sch_arr_dt": "1443100980",
+				"sch_dep_dt": "1443100980",
+				"pre_dt": "1443106861",
+				"pre_away": "1184"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70081",
+				"stop_name": "Broadway - Outbound",
+				"sch_arr_dt": "1443101160",
+				"sch_dep_dt": "1443101160",
+				"pre_dt": "1443107009",
+				"pre_away": "1332"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70083",
+				"stop_name": "Andrew - Outbound",
+				"sch_arr_dt": "1443101280",
+				"sch_dep_dt": "1443101280",
+				"pre_dt": "1443107134",
+				"pre_away": "1457"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70095",
+				"stop_name": "JFK/UMASS Braintree - Outbound",
+				"sch_arr_dt": "1443101400",
+				"sch_dep_dt": "1443101400",
+				"pre_dt": "1443107291",
+				"pre_away": "1614"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70097",
+				"stop_name": "North Quincy - Outbound",
+				"sch_arr_dt": "1443101820",
+				"sch_dep_dt": "1443101820",
+				"pre_dt": "1443107743",
+				"pre_away": "2066"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70099",
+				"stop_name": "Wollaston - Outbound",
+				"sch_arr_dt": "1443102000",
+				"sch_dep_dt": "1443102000",
+				"pre_dt": "1443107863",
+				"pre_away": "2186"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70101",
+				"stop_name": "Quincy Center - Outbound",
+				"sch_arr_dt": "1443102180",
+				"sch_dep_dt": "1443102180",
+				"pre_dt": "1443108043",
+				"pre_away": "2366"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70103",
+				"stop_name": "Quincy Adams - Outbound",
+				"sch_arr_dt": "1443102420",
+				"sch_dep_dt": "1443102420",
+				"pre_dt": "1443108223",
+				"pre_away": "2546"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443102660",
+				"sch_dep_dt": "1443102660",
+				"pre_dt": "1443108505",
+				"pre_away": "2828"
+			}]
+		}, {
+			"trip_id": "28192814",
+			"trip_name": "9:07 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443100020",
+				"sch_dep_dt": "1443100020",
+				"pre_dt": "1443106083",
+				"pre_away": "406"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443100200",
+				"sch_dep_dt": "1443100200",
+				"pre_dt": "1443106195",
+				"pre_away": "518"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443100320",
+				"sch_dep_dt": "1443100320",
+				"pre_dt": "1443106328",
+				"pre_away": "651"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443100500",
+				"sch_dep_dt": "1443100500",
+				"pre_dt": "1443106493",
+				"pre_away": "816"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443100680",
+				"sch_dep_dt": "1443100680",
+				"pre_dt": "1443106703",
+				"pre_away": "1026"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443100860",
+				"sch_dep_dt": "1443100860",
+				"pre_dt": "1443106871",
+				"pre_away": "1194"
+			}]
+		}, {
+			"trip_id": "28192815",
+			"trip_name": "9:16 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443100560",
+				"sch_dep_dt": "1443100560",
+				"pre_dt": "1443106507",
+				"pre_away": "830"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443100740",
+				"sch_dep_dt": "1443100740",
+				"pre_dt": "1443106619",
+				"pre_away": "942"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443100860",
+				"sch_dep_dt": "1443100860",
+				"pre_dt": "1443106752",
+				"pre_away": "1075"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443101040",
+				"sch_dep_dt": "1443101040",
+				"pre_dt": "1443106917",
+				"pre_away": "1240"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443101220",
+				"sch_dep_dt": "1443101220",
+				"pre_dt": "1443107128",
+				"pre_away": "1451"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443101400",
+				"sch_dep_dt": "1443101400",
+				"pre_dt": "1443107291",
+				"pre_away": "1614"
+			}]
+		}, {
+			"trip_id": "28192816",
+			"trip_name": "9:24 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443101040",
+				"sch_dep_dt": "1443101040",
+				"pre_dt": "1443107622",
+				"pre_away": "1945"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443101220",
+				"sch_dep_dt": "1443101220",
+				"pre_dt": "1443107734",
+				"pre_away": "2057"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443101340",
+				"sch_dep_dt": "1443101340",
+				"pre_dt": "1443107867",
+				"pre_away": "2190"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443101520",
+				"sch_dep_dt": "1443101520",
+				"pre_dt": "1443108032",
+				"pre_away": "2355"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443101700",
+				"sch_dep_dt": "1443101700",
+				"pre_dt": "1443108242",
+				"pre_away": "2565"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443101820",
+				"sch_dep_dt": "1443101820",
+				"pre_dt": "1443108405",
+				"pre_away": "2728"
+			}]
+		}, {
+			"trip_id": "28192701",
+			"trip_name": "10:19 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104340",
+				"sch_dep_dt": "1443104340",
+				"pre_dt": "1443107142",
+				"pre_away": "1465"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443104520",
+				"sch_dep_dt": "1443104520",
+				"pre_dt": "1443107254",
+				"pre_away": "1577"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443104640",
+				"sch_dep_dt": "1443104640",
+				"pre_dt": "1443107387",
+				"pre_away": "1710"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443104820",
+				"sch_dep_dt": "1443104820",
+				"pre_dt": "1443107552",
+				"pre_away": "1875"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443105000",
+				"sch_dep_dt": "1443105000",
+				"pre_dt": "1443107762",
+				"pre_away": "2085"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443107926",
+				"pre_away": "2249"
+			}]
+		}, {
+			"trip_id": "28192823",
+			"trip_name": "10:24 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104640",
+				"sch_dep_dt": "1443104640",
+				"pre_dt": "1443108131",
+				"pre_away": "2454"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443104820",
+				"sch_dep_dt": "1443104820",
+				"pre_dt": "1443108243",
+				"pre_away": "2566"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443104940",
+				"sch_dep_dt": "1443104940",
+				"pre_dt": "1443108376",
+				"pre_away": "2699"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443108541",
+				"pre_away": "2864"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443105300",
+				"sch_dep_dt": "1443105300",
+				"pre_dt": "1443108752",
+				"pre_away": "3075"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443108915",
+				"pre_away": "3238"
+			}]
+		}, {
+			"trip_id": "28192720",
+			"trip_name": "10:29 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104940",
+				"sch_dep_dt": "1443104940",
+				"pre_dt": "1443108194",
+				"pre_away": "2517"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443108306",
+				"pre_away": "2629"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443108439",
+				"pre_away": "2762"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443108604",
+				"pre_away": "2927"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443108815",
+				"pre_away": "3138"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443108978",
+				"pre_away": "3301"
+			}]
+		}, {
+			"trip_id": "28192824",
+			"trip_name": "10:34 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443108411",
+				"pre_away": "2734"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443108523",
+				"pre_away": "2846"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443108656",
+				"pre_away": "2979"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443108821",
+				"pre_away": "3144"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443109032",
+				"pre_away": "3355"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443109195",
+				"pre_away": "3518"
+			}]
+		}, {
+			"trip_id": "28192721",
+			"trip_name": "10:39 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443108294",
+				"pre_away": "2617"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443108406",
+				"pre_away": "2729"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443108539",
+				"pre_away": "2862"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443108704",
+				"pre_away": "3027"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443108915",
+				"pre_away": "3238"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443109078",
+				"pre_away": "3401"
+			}]
+		}, {
+			"trip_id": "28192825",
+			"trip_name": "10:45 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443108848",
+				"pre_away": "3171"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443108960",
+				"pre_away": "3283"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443109093",
+				"pre_away": "3416"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443109258",
+				"pre_away": "3581"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443109468",
+				"pre_away": "3791"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443109631",
+				"pre_away": "3954"
+			}]
+		}, {
+			"trip_id": "28192962",
+			"trip_name": "10:51 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443108637",
+				"pre_away": "2960"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443108749",
+				"pre_away": "3072"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443108882",
+				"pre_away": "3205"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443106740",
+				"sch_dep_dt": "1443106740",
+				"pre_dt": "1443109047",
+				"pre_away": "3370"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443109258",
+				"pre_away": "3581"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443107040",
+				"sch_dep_dt": "1443107040",
+				"pre_dt": "1443109421",
+				"pre_away": "3744"
+			}]
+		}, {
+			"trip_id": "28192967",
+			"trip_name": "10:58 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443109188",
+				"pre_away": "3511"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443109300",
+				"pre_away": "3623"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443106980",
+				"sch_dep_dt": "1443106980",
+				"pre_dt": "1443109433",
+				"pre_away": "3756"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443109598",
+				"pre_away": "3921"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443109808",
+				"pre_away": "4131"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443107460",
+				"sch_dep_dt": "1443107460",
+				"pre_dt": "1443109971",
+				"pre_away": "4294"
+			}]
+		}, {
+			"trip_id": "28193211",
+			"trip_name": "11:05 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443107100",
+				"sch_dep_dt": "1443107100",
+				"pre_dt": "1443109278",
+				"pre_away": "3601"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443107280",
+				"sch_dep_dt": "1443107280",
+				"pre_dt": "1443109390",
+				"pre_away": "3713"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443109523",
+				"pre_away": "3846"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443109688",
+				"pre_away": "4011"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443107760",
+				"sch_dep_dt": "1443107760",
+				"pre_dt": "1443109899",
+				"pre_away": "4222"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443107880",
+				"sch_dep_dt": "1443107880",
+				"pre_dt": "1443110062",
+				"pre_away": "4385"
+			}]
+		}, {
+			"trip_id": "28193218",
+			"trip_name": "11:12 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443107520",
+				"sch_dep_dt": "1443107520",
+				"pre_dt": "1443110119",
+				"pre_away": "4442"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443107700",
+				"sch_dep_dt": "1443107700",
+				"pre_dt": "1443110231",
+				"pre_away": "4554"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443107820",
+				"sch_dep_dt": "1443107820",
+				"pre_dt": "1443110364",
+				"pre_away": "4687"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443108000",
+				"sch_dep_dt": "1443108000",
+				"pre_dt": "1443110529",
+				"pre_away": "4852"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443108180",
+				"sch_dep_dt": "1443108180",
+				"pre_dt": "1443110739",
+				"pre_away": "5062"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443108300",
+				"sch_dep_dt": "1443108300",
+				"pre_dt": "1443110902",
+				"pre_away": "5225"
+			}]
+		}, {
+			"trip_id": "28193212",
+			"trip_name": "11:19 am from Alewife to Ashmont - Outbound",
+			"trip_headsign": "Ashmont",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443107940",
+				"sch_dep_dt": "1443107940",
+				"pre_dt": "1443110132",
+				"pre_away": "4455"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443108120",
+				"sch_dep_dt": "1443108120",
+				"pre_dt": "1443110244",
+				"pre_away": "4567"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443108240",
+				"sch_dep_dt": "1443108240",
+				"pre_dt": "1443110377",
+				"pre_away": "4700"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443108420",
+				"sch_dep_dt": "1443108420",
+				"pre_dt": "1443110542",
+				"pre_away": "4865"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443108600",
+				"sch_dep_dt": "1443108600",
+				"pre_dt": "1443110753",
+				"pre_away": "5076"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443108720",
+				"sch_dep_dt": "1443108720",
+				"pre_dt": "1443110916",
+				"pre_away": "5239"
+			}]
+		}, {
+			"trip_id": "28193219",
+			"trip_name": "11:26 am from Alewife to Braintree",
+			"trip_headsign": "Braintree",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443108360",
+				"sch_dep_dt": "1443108360",
+				"pre_dt": "1443111118",
+				"pre_away": "5441"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70063",
+				"stop_name": "Davis - Inbound",
+				"sch_arr_dt": "1443108540",
+				"sch_dep_dt": "1443108540",
+				"pre_dt": "1443111230",
+				"pre_away": "5553"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70065",
+				"stop_name": "Porter - Inbound",
+				"sch_arr_dt": "1443108660",
+				"sch_dep_dt": "1443108660",
+				"pre_dt": "1443111363",
+				"pre_away": "5686"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70067",
+				"stop_name": "Harvard - Inbound",
+				"sch_arr_dt": "1443108840",
+				"sch_dep_dt": "1443108840",
+				"pre_dt": "1443111528",
+				"pre_away": "5851"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70069",
+				"stop_name": "Central - Inbound",
+				"sch_arr_dt": "1443109020",
+				"sch_dep_dt": "1443109020",
+				"pre_dt": "1443111738",
+				"pre_away": "6061"
+			}, {
+				"stop_sequence": "50",
+				"stop_id": "70071",
+				"stop_name": "Kendall/MIT - Inbound",
+				"sch_arr_dt": "1443109140",
+				"sch_dep_dt": "1443109140",
+				"pre_dt": "1443111901",
+				"pre_away": "6224"
+			}]
+		}]
+	}, {
+		"direction_id": "1",
+		"direction_name": "Northbound",
+		"trip": [{
+			"trip_id": "28192679",
+			"trip_name": "7:40 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "60",
+				"stop_id": "70092",
+				"stop_name": "Shawmut - Inbound",
+				"sch_arr_dt": "1443094920",
+				"sch_dep_dt": "1443094920",
+				"pre_dt": "1443105715",
+				"pre_away": "38"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70090",
+				"stop_name": "Fields Corner - Inbound",
+				"sch_arr_dt": "1443095040",
+				"sch_dep_dt": "1443095040",
+				"pre_dt": "1443105829",
+				"pre_away": "152"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70088",
+				"stop_name": "Savin Hill - Inbound",
+				"sch_arr_dt": "1443095220",
+				"sch_dep_dt": "1443095220",
+				"pre_dt": "1443106007",
+				"pre_away": "330"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70086",
+				"stop_name": "JFK/UMASS Ashmont - Inbound",
+				"sch_arr_dt": "1443095340",
+				"sch_dep_dt": "1443095340",
+				"pre_dt": "1443106145",
+				"pre_away": "468"
+			}]
+		}, {
+			"trip_id": "28192681",
+			"trip_name": "7:57 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "50",
+				"stop_id": "70094",
+				"stop_name": "Ashmont - Inbound",
+				"sch_arr_dt": "1443095820",
+				"sch_dep_dt": "1443095820",
+				"pre_dt": "1443106395",
+				"pre_away": "718"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70092",
+				"stop_name": "Shawmut - Inbound",
+				"sch_arr_dt": "1443095940",
+				"sch_dep_dt": "1443095940",
+				"pre_dt": "1443106467",
+				"pre_away": "790"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70090",
+				"stop_name": "Fields Corner - Inbound",
+				"sch_arr_dt": "1443096060",
+				"sch_dep_dt": "1443096060",
+				"pre_dt": "1443106581",
+				"pre_away": "904"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70088",
+				"stop_name": "Savin Hill - Inbound",
+				"sch_arr_dt": "1443096240",
+				"sch_dep_dt": "1443096240",
+				"pre_dt": "1443106759",
+				"pre_away": "1082"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70086",
+				"stop_name": "JFK/UMASS Ashmont - Inbound",
+				"sch_arr_dt": "1443096360",
+				"sch_dep_dt": "1443096360",
+				"pre_dt": "1443106897",
+				"pre_away": "1220"
+			}]
+		}, {
+			"trip_id": "28192866",
+			"trip_name": "8:07 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1517",
+				"vehicle_lat": "42.39638",
+				"vehicle_lon": "-71.1386",
+				"vehicle_bearing": "260",
+				"vehicle_timestamp": "1443105313"
+			},
+			"stop": [{
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443099660",
+				"sch_dep_dt": "1443099660",
+				"pre_dt": "1443105844",
+				"pre_away": "167"
+			}]
+		}, {
+			"trip_id": "28192867",
+			"trip_name": "8:16 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1874",
+				"vehicle_lat": "42.39751",
+				"vehicle_lon": "-71.12572",
+				"vehicle_bearing": "275",
+				"vehicle_timestamp": "1443105636"
+			},
+			"stop": [{
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443100200",
+				"sch_dep_dt": "1443100200",
+				"pre_dt": "1443106268",
+				"pre_away": "591"
+			}]
+		}, {
+			"trip_id": "28192868",
+			"trip_name": "8:24 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1842",
+				"vehicle_lat": "42.38416",
+				"vehicle_lon": "-71.11936",
+				"vehicle_bearing": "0",
+				"vehicle_timestamp": "1443105535"
+			},
+			"stop": [{
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443100260",
+				"sch_dep_dt": "1443100260",
+				"pre_dt": "1443105797",
+				"pre_away": "120"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443100440",
+				"sch_dep_dt": "1443100440",
+				"pre_dt": "1443106188",
+				"pre_away": "511"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443100680",
+				"sch_dep_dt": "1443100680",
+				"pre_dt": "1443107383",
+				"pre_away": "1706"
+			}]
+		}, {
+			"trip_id": "28192690",
+			"trip_name": "9:13 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "50",
+				"stop_id": "70094",
+				"stop_name": "Ashmont - Inbound",
+				"sch_arr_dt": "1443100380",
+				"sch_dep_dt": "1443100380",
+				"pre_dt": "1443107320",
+				"pre_away": "1643"
+			}, {
+				"stop_sequence": "60",
+				"stop_id": "70092",
+				"stop_name": "Shawmut - Inbound",
+				"sch_arr_dt": "1443100500",
+				"sch_dep_dt": "1443100500",
+				"pre_dt": "1443107392",
+				"pre_away": "1715"
+			}, {
+				"stop_sequence": "70",
+				"stop_id": "70090",
+				"stop_name": "Fields Corner - Inbound",
+				"sch_arr_dt": "1443100620",
+				"sch_dep_dt": "1443100620",
+				"pre_dt": "1443107506",
+				"pre_away": "1829"
+			}, {
+				"stop_sequence": "80",
+				"stop_id": "70088",
+				"stop_name": "Savin Hill - Inbound",
+				"sch_arr_dt": "1443100800",
+				"sch_dep_dt": "1443100800",
+				"pre_dt": "1443107684",
+				"pre_away": "2007"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70086",
+				"stop_name": "JFK/UMASS Ashmont - Inbound",
+				"sch_arr_dt": "1443100920",
+				"sch_dep_dt": "1443100920",
+				"pre_dt": "1443107822",
+				"pre_away": "2145"
+			}]
+		}, {
+			"trip_id": "28192952",
+			"trip_name": "9:25 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443101100",
+				"sch_dep_dt": "1443101100",
+				"pre_dt": "1443106150",
+				"pre_away": "473"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70104",
+				"stop_name": "Quincy Adams - Inbound",
+				"sch_arr_dt": "1443101340",
+				"sch_dep_dt": "1443101340",
+				"pre_dt": "1443106399",
+				"pre_away": "722"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound",
+				"sch_arr_dt": "1443101520",
+				"sch_dep_dt": "1443101520",
+				"pre_dt": "1443106583",
+				"pre_away": "906"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound",
+				"sch_arr_dt": "1443101700",
+				"sch_dep_dt": "1443101700",
+				"pre_dt": "1443106782",
+				"pre_away": "1105"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound",
+				"sch_arr_dt": "1443101820",
+				"sch_dep_dt": "1443101820",
+				"pre_dt": "1443106941",
+				"pre_away": "1264"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443102240",
+				"sch_dep_dt": "1443102240",
+				"pre_dt": "1443107438",
+				"pre_away": "1761"
+			}]
+		}, {
+			"trip_id": "28192875",
+			"trip_name": "9:30 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443101400",
+				"sch_dep_dt": "1443101400",
+				"pre_dt": "1443108094",
+				"pre_away": "2417"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70104",
+				"stop_name": "Quincy Adams - Inbound",
+				"sch_arr_dt": "1443101640",
+				"sch_dep_dt": "1443101640",
+				"pre_dt": "1443108343",
+				"pre_away": "2666"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound",
+				"sch_arr_dt": "1443101820",
+				"sch_dep_dt": "1443101820",
+				"pre_dt": "1443108527",
+				"pre_away": "2850"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound",
+				"sch_arr_dt": "1443102000",
+				"sch_dep_dt": "1443102000",
+				"pre_dt": "1443108726",
+				"pre_away": "3049"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound",
+				"sch_arr_dt": "1443102120",
+				"sch_dep_dt": "1443102120",
+				"pre_dt": "1443108885",
+				"pre_away": "3208"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443102540",
+				"sch_dep_dt": "1443102540",
+				"pre_dt": "1443109382",
+				"pre_away": "3705"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443103740",
+				"sch_dep_dt": "1443103740",
+				"pre_dt": "1443105896",
+				"pre_away": "219"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443103920",
+				"sch_dep_dt": "1443103920",
+				"pre_dt": "1443106456",
+				"pre_away": "779"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443104100",
+				"sch_dep_dt": "1443104100",
+				"pre_dt": "1443106786",
+				"pre_away": "1109"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104340",
+				"sch_dep_dt": "1443104340",
+				"pre_dt": "1443107892",
+				"pre_away": "2215"
+			}]
+		}, {
+			"trip_id": "28192692",
+			"trip_name": "9:31 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1641",
+				"vehicle_lat": "42.38923",
+				"vehicle_lon": "-71.11931",
+				"vehicle_bearing": "0",
+				"vehicle_timestamp": "1443105342"
+			},
+			"stop": [{
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443103560",
+				"sch_dep_dt": "1443103560",
+				"pre_dt": "1443105708",
+				"pre_away": "31"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443103800",
+				"sch_dep_dt": "1443103800",
+				"pre_dt": "1443106903",
+				"pre_away": "1226"
+			}]
+		}, {
+			"trip_id": "28192876",
+			"trip_name": "9:39 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1729",
+				"vehicle_lat": "42.36267",
+				"vehicle_lon": "-71.08724",
+				"vehicle_bearing": "275",
+				"vehicle_timestamp": "1443105647"
+			},
+			"stop": [{
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443104100",
+				"sch_dep_dt": "1443104100",
+				"pre_dt": "1443105826",
+				"pre_away": "149"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443104280",
+				"sch_dep_dt": "1443104280",
+				"pre_dt": "1443106420",
+				"pre_away": "743"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443104460",
+				"sch_dep_dt": "1443104460",
+				"pre_dt": "1443106736",
+				"pre_away": "1059"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443104640",
+				"sch_dep_dt": "1443104640",
+				"pre_dt": "1443107384",
+				"pre_away": "1707"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104880",
+				"sch_dep_dt": "1443104880",
+				"pre_dt": "1443108172",
+				"pre_away": "2495"
+			}]
+		}, {
+			"trip_id": "28192714",
+			"trip_name": "9:44 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1702",
+				"vehicle_lat": "42.37246",
+				"vehicle_lon": "-71.11586",
+				"vehicle_bearing": "330",
+				"vehicle_timestamp": "1443105634"
+			},
+			"stop": [{
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443104160",
+				"sch_dep_dt": "1443104160",
+				"pre_dt": "1443106307",
+				"pre_away": "630"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443104340",
+				"sch_dep_dt": "1443104340",
+				"pre_dt": "1443106487",
+				"pre_away": "810"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443104580",
+				"sch_dep_dt": "1443104580",
+				"pre_dt": "1443107955",
+				"pre_away": "2278"
+			}]
+		}, {
+			"trip_id": "28192877",
+			"trip_name": "9:49 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1801",
+				"vehicle_lat": "42.35937",
+				"vehicle_lon": "-71.06741",
+				"vehicle_bearing": "315",
+				"vehicle_timestamp": "1443105593"
+			},
+			"stop": [{
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443104460",
+				"sch_dep_dt": "1443104460",
+				"pre_dt": "1443105676",
+				"pre_away": "0"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443104580",
+				"sch_dep_dt": "1443104580",
+				"pre_dt": "1443105875",
+				"pre_away": "198"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443104700",
+				"sch_dep_dt": "1443104700",
+				"pre_dt": "1443106051",
+				"pre_away": "374"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443104880",
+				"sch_dep_dt": "1443104880",
+				"pre_dt": "1443106828",
+				"pre_away": "1151"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443105060",
+				"sch_dep_dt": "1443105060",
+				"pre_dt": "1443107023",
+				"pre_away": "1346"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443107645",
+				"pre_away": "1968"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443108609",
+				"pre_away": "2932"
+			}]
+		}, {
+			"trip_id": "28192966",
+			"trip_name": "9:54 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443102840",
+				"sch_dep_dt": "1443102840",
+				"pre_dt": "1443107252",
+				"pre_away": "1575"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70104",
+				"stop_name": "Quincy Adams - Inbound",
+				"sch_arr_dt": "1443103080",
+				"sch_dep_dt": "1443103080",
+				"pre_dt": "1443107501",
+				"pre_away": "1824"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound",
+				"sch_arr_dt": "1443103260",
+				"sch_dep_dt": "1443103260",
+				"pre_dt": "1443107685",
+				"pre_away": "2008"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound",
+				"sch_arr_dt": "1443103440",
+				"sch_dep_dt": "1443103440",
+				"pre_dt": "1443107884",
+				"pre_away": "2207"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound",
+				"sch_arr_dt": "1443103560",
+				"sch_dep_dt": "1443103560",
+				"pre_dt": "1443108043",
+				"pre_away": "2366"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443103980",
+				"sch_dep_dt": "1443103980",
+				"pre_dt": "1443108540",
+				"pre_away": "2863"
+			}]
+		}, {
+			"trip_id": "28192715",
+			"trip_name": "9:55 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1755",
+				"vehicle_lat": "42.36316",
+				"vehicle_lon": "-71.09416",
+				"vehicle_bearing": "275",
+				"vehicle_timestamp": "1443105441"
+			},
+			"stop": [{
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443104640",
+				"sch_dep_dt": "1443104640",
+				"pre_dt": "1443106158",
+				"pre_away": "481"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443104820",
+				"sch_dep_dt": "1443104820",
+				"pre_dt": "1443106619",
+				"pre_away": "942"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443105000",
+				"sch_dep_dt": "1443105000",
+				"pre_dt": "1443107085",
+				"pre_away": "1408"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443108055",
+				"pre_away": "2378"
+			}]
+		}, {
+			"trip_id": "28192953",
+			"trip_name": "10:04 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"stop": [{
+				"stop_sequence": "1",
+				"stop_id": "70105",
+				"stop_name": "Braintree",
+				"sch_arr_dt": "1443103440",
+				"sch_dep_dt": "1443103440",
+				"pre_dt": "1443108673",
+				"pre_away": "2996"
+			}, {
+				"stop_sequence": "10",
+				"stop_id": "70104",
+				"stop_name": "Quincy Adams - Inbound",
+				"sch_arr_dt": "1443103680",
+				"sch_dep_dt": "1443103680",
+				"pre_dt": "1443108922",
+				"pre_away": "3245"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound",
+				"sch_arr_dt": "1443103860",
+				"sch_dep_dt": "1443103860",
+				"pre_dt": "1443109106",
+				"pre_away": "3429"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound",
+				"sch_arr_dt": "1443104040",
+				"sch_dep_dt": "1443104040",
+				"pre_dt": "1443109305",
+				"pre_away": "3628"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound",
+				"sch_arr_dt": "1443104160",
+				"sch_dep_dt": "1443104160",
+				"pre_dt": "1443109464",
+				"pre_away": "3787"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443104580",
+				"sch_dep_dt": "1443104580",
+				"pre_dt": "1443109961",
+				"pre_away": "4284"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70076",
+				"stop_name": "Park Street - to Alewife",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443105797",
+				"pre_away": "120"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443106023",
+				"pre_away": "346"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443106215",
+				"pre_away": "538"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443106388",
+				"pre_away": "711"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443107090",
+				"pre_away": "1413"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443107363",
+				"pre_away": "1686"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443107882",
+				"pre_away": "2205"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443108949",
+				"pre_away": "3272"
+			}]
+		}, {
+			"trip_id": "28192963",
+			"trip_name": "10:08 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1607",
+				"vehicle_lat": "42.36203",
+				"vehicle_lon": "-71.08088",
+				"vehicle_bearing": "275",
+				"vehicle_timestamp": "1443105613"
+			},
+			"stop": [{
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443105120",
+				"sch_dep_dt": "1443105120",
+				"pre_dt": "1443105664",
+				"pre_away": "12"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443105240",
+				"sch_dep_dt": "1443105240",
+				"pre_dt": "1443105949",
+				"pre_away": "272"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443105420",
+				"sch_dep_dt": "1443105420",
+				"pre_dt": "1443106601",
+				"pre_away": "924"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443106812",
+				"pre_away": "1135"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443107408",
+				"pre_away": "1731"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443108398",
+				"pre_away": "2721"
+			}]
+		}, {
+			"trip_id": "28193202",
+			"trip_name": "10:17 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1508",
+				"vehicle_lat": "42.30663",
+				"vehicle_lon": "-71.0546",
+				"vehicle_bearing": "10",
+				"vehicle_timestamp": "1443105568"
+			},
+			"stop": [{
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443105360",
+				"sch_dep_dt": "1443105360",
+				"pre_dt": "1443105744",
+				"pre_away": "67"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70084",
+				"stop_name": "Andrew - Inbound",
+				"sch_arr_dt": "1443105540",
+				"sch_dep_dt": "1443105540",
+				"pre_dt": "1443105911",
+				"pre_away": "234"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70082",
+				"stop_name": "Broadway - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443106054",
+				"pre_away": "377"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70080",
+				"stop_name": "South Station - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106223",
+				"pre_away": "546"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife",
+				"sch_arr_dt": "1443105900",
+				"sch_dep_dt": "1443105900",
+				"pre_dt": "1443106406",
+				"pre_away": "729"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70076",
+				"stop_name": "Park Street - to Alewife",
+				"sch_arr_dt": "1443106020",
+				"sch_dep_dt": "1443106020",
+				"pre_dt": "1443106715",
+				"pre_away": "1038"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443106947",
+				"pre_away": "1270"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443106260",
+				"sch_dep_dt": "1443106260",
+				"pre_dt": "1443107146",
+				"pre_away": "1469"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443107319",
+				"pre_away": "1642"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443107694",
+				"pre_away": "2017"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443106740",
+				"sch_dep_dt": "1443106740",
+				"pre_dt": "1443108294",
+				"pre_away": "2617"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443106920",
+				"sch_dep_dt": "1443106920",
+				"pre_dt": "1443108685",
+				"pre_away": "3008"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443109880",
+				"pre_away": "4203"
+			}]
+		}, {
+			"trip_id": "28193172",
+			"trip_name": "10:20 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1737",
+				"vehicle_lat": "42.35266",
+				"vehicle_lon": "-71.05536",
+				"vehicle_bearing": "290",
+				"vehicle_timestamp": "1443105543"
+			},
+			"stop": [{
+				"stop_sequence": "140",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105747",
+				"pre_away": "70"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70076",
+				"stop_name": "Park Street - to Alewife",
+				"sch_arr_dt": "1443105600",
+				"sch_dep_dt": "1443105600",
+				"pre_dt": "1443106036",
+				"pre_away": "359"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443105720",
+				"sch_dep_dt": "1443105720",
+				"pre_dt": "1443106262",
+				"pre_away": "585"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443105840",
+				"sch_dep_dt": "1443105840",
+				"pre_dt": "1443106454",
+				"pre_away": "777"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443106627",
+				"pre_away": "950"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443106140",
+				"sch_dep_dt": "1443106140",
+				"pre_dt": "1443107352",
+				"pre_away": "1675"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443107603",
+				"pre_away": "1926"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443106500",
+				"sch_dep_dt": "1443106500",
+				"pre_dt": "1443108181",
+				"pre_away": "2504"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443106740",
+				"sch_dep_dt": "1443106740",
+				"pre_dt": "1443109039",
+				"pre_away": "3362"
+			}]
+		}, {
+			"trip_id": "28193185",
+			"trip_name": "10:31 am from Braintree to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1846",
+				"vehicle_lat": "42.22099",
+				"vehicle_lon": "-71.00101",
+				"vehicle_bearing": "330",
+				"vehicle_timestamp": "1443105590"
+			},
+			"stop": [{
+				"stop_sequence": "10",
+				"stop_id": "70104",
+				"stop_name": "Quincy Adams - Inbound",
+				"sch_arr_dt": "1443105300",
+				"sch_dep_dt": "1443105300",
+				"pre_dt": "1443105704",
+				"pre_away": "27"
+			}, {
+				"stop_sequence": "20",
+				"stop_id": "70102",
+				"stop_name": "Quincy Center - Inbound",
+				"sch_arr_dt": "1443105480",
+				"sch_dep_dt": "1443105480",
+				"pre_dt": "1443105888",
+				"pre_away": "211"
+			}, {
+				"stop_sequence": "30",
+				"stop_id": "70100",
+				"stop_name": "Wollaston - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443106087",
+				"pre_away": "410"
+			}, {
+				"stop_sequence": "40",
+				"stop_id": "70098",
+				"stop_name": "North Quincy - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443106246",
+				"pre_away": "569"
+			}, {
+				"stop_sequence": "100",
+				"stop_id": "70096",
+				"stop_name": "JFK/UMASS Braintree - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106743",
+				"pre_away": "1066"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70084",
+				"stop_name": "Andrew - Inbound",
+				"sch_arr_dt": "1443106380",
+				"sch_dep_dt": "1443106380",
+				"pre_dt": "1443106910",
+				"pre_away": "1233"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70082",
+				"stop_name": "Broadway - Inbound",
+				"sch_arr_dt": "1443106500",
+				"sch_dep_dt": "1443106500",
+				"pre_dt": "1443107053",
+				"pre_away": "1376"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70080",
+				"stop_name": "South Station - Inbound",
+				"sch_arr_dt": "1443106620",
+				"sch_dep_dt": "1443106620",
+				"pre_dt": "1443107222",
+				"pre_away": "1545"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife",
+				"sch_arr_dt": "1443106740",
+				"sch_dep_dt": "1443106740",
+				"pre_dt": "1443107405",
+				"pre_away": "1728"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70076",
+				"stop_name": "Park Street - to Alewife",
+				"sch_arr_dt": "1443106860",
+				"sch_dep_dt": "1443106860",
+				"pre_dt": "1443107714",
+				"pre_away": "2037"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443106980",
+				"sch_dep_dt": "1443106980",
+				"pre_dt": "1443107946",
+				"pre_away": "2269"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443107100",
+				"sch_dep_dt": "1443107100",
+				"pre_dt": "1443108145",
+				"pre_away": "2468"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443107220",
+				"sch_dep_dt": "1443107220",
+				"pre_dt": "1443108318",
+				"pre_away": "2641"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443107400",
+				"sch_dep_dt": "1443107400",
+				"pre_dt": "1443108693",
+				"pre_away": "3016"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443109293",
+				"pre_away": "3616"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443107760",
+				"sch_dep_dt": "1443107760",
+				"pre_dt": "1443109684",
+				"pre_away": "4007"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443108000",
+				"sch_dep_dt": "1443108000",
+				"pre_dt": "1443110879",
+				"pre_away": "5202"
+			}]
+		}, {
+			"trip_id": "28193160",
+			"trip_name": "10:34 am from Ashmont - Inbound to Alewife",
+			"trip_headsign": "Alewife",
+			"vehicle": {
+				"vehicle_id": "1815",
+				"vehicle_lat": "42.3028",
+				"vehicle_lon": "-71.05578",
+				"vehicle_bearing": "5",
+				"vehicle_timestamp": "1443105603"
+			},
+			"stop": [{
+				"stop_sequence": "80",
+				"stop_id": "70088",
+				"stop_name": "Savin Hill - Inbound",
+				"sch_arr_dt": "1443105660",
+				"sch_dep_dt": "1443105660",
+				"pre_dt": "1443105661",
+				"pre_away": "15"
+			}, {
+				"stop_sequence": "90",
+				"stop_id": "70086",
+				"stop_name": "JFK/UMASS Ashmont - Inbound",
+				"sch_arr_dt": "1443105780",
+				"sch_dep_dt": "1443105780",
+				"pre_dt": "1443105799",
+				"pre_away": "122"
+			}, {
+				"stop_sequence": "110",
+				"stop_id": "70084",
+				"stop_name": "Andrew - Inbound",
+				"sch_arr_dt": "1443105960",
+				"sch_dep_dt": "1443105960",
+				"pre_dt": "1443105957",
+				"pre_away": "280"
+			}, {
+				"stop_sequence": "120",
+				"stop_id": "70082",
+				"stop_name": "Broadway - Inbound",
+				"sch_arr_dt": "1443106080",
+				"sch_dep_dt": "1443106080",
+				"pre_dt": "1443106100",
+				"pre_away": "423"
+			}, {
+				"stop_sequence": "130",
+				"stop_id": "70080",
+				"stop_name": "South Station - Inbound",
+				"sch_arr_dt": "1443106200",
+				"sch_dep_dt": "1443106200",
+				"pre_dt": "1443106269",
+				"pre_away": "592"
+			}, {
+				"stop_sequence": "140",
+				"stop_id": "70078",
+				"stop_name": "Downtown Crossing - to Alewife",
+				"sch_arr_dt": "1443106320",
+				"sch_dep_dt": "1443106320",
+				"pre_dt": "1443106452",
+				"pre_away": "775"
+			}, {
+				"stop_sequence": "150",
+				"stop_id": "70076",
+				"stop_name": "Park Street - to Alewife",
+				"sch_arr_dt": "1443106440",
+				"sch_dep_dt": "1443106440",
+				"pre_dt": "1443106741",
+				"pre_away": "1064"
+			}, {
+				"stop_sequence": "160",
+				"stop_id": "70074",
+				"stop_name": "Charles/MGH - Outbound",
+				"sch_arr_dt": "1443106560",
+				"sch_dep_dt": "1443106560",
+				"pre_dt": "1443106967",
+				"pre_away": "1290"
+			}, {
+				"stop_sequence": "170",
+				"stop_id": "70072",
+				"stop_name": "Kendall/MIT - Outbound",
+				"sch_arr_dt": "1443106680",
+				"sch_dep_dt": "1443106680",
+				"pre_dt": "1443107159",
+				"pre_away": "1482"
+			}, {
+				"stop_sequence": "180",
+				"stop_id": "70070",
+				"stop_name": "Central - Outbound",
+				"sch_arr_dt": "1443106800",
+				"sch_dep_dt": "1443106800",
+				"pre_dt": "1443107332",
+				"pre_away": "1655"
+			}, {
+				"stop_sequence": "190",
+				"stop_id": "70068",
+				"stop_name": "Harvard - Outbound",
+				"sch_arr_dt": "1443106980",
+				"sch_dep_dt": "1443106980",
+				"pre_dt": "1443107707",
+				"pre_away": "2030"
+			}, {
+				"stop_sequence": "200",
+				"stop_id": "70066",
+				"stop_name": "Porter - Outbound",
+				"sch_arr_dt": "1443107160",
+				"sch_dep_dt": "1443107160",
+				"pre_dt": "1443108307",
+				"pre_away": "2630"
+			}, {
+				"stop_sequence": "210",
+				"stop_id": "70064",
+				"stop_name": "Davis - Outbound",
+				"sch_arr_dt": "1443107340",
+				"sch_dep_dt": "1443107340",
+				"pre_dt": "1443108698",
+				"pre_away": "3021"
+			}, {
+				"stop_sequence": "220",
+				"stop_id": "70061",
+				"stop_name": "Alewife",
+				"sch_arr_dt": "1443107580",
+				"sch_dep_dt": "1443107580",
+				"pre_dt": "1443109893",
+				"pre_away": "4216"
+			}]
+		}]
+	}],
+	"alert_headers": [{
+		"alert_id": 88088,
+		"header_text": "Downtown Crossing: The Franklin St entrance will be closed on Monday, August 10, and will remain closed until Summer 2016 to accommodate ongoing construction for the Millennium Tower Project.",
+		"effect_name": "Station Issue"
+	}, {
+		"alert_id": 95292,
+		"header_text": "Red Line experiencing severe delays in both directions due to a signal problem at Alewife Station.",
+		"effect_name": "Delay"
+	}]
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jshint-stylish": "^1.0.2",
     "load-grunt-tasks": "^2.0.0",
     "lodash.union": "^3.1.0",
+    "minimist": "^1.2.0",
     "mocha": "^2.3.2",
     "proxyquire": "^1.7.2",
     "replay": "^2.0.6"


### PR DESCRIPTION
This adds fixtures for a number of different predictions scenarios (late night, service delays, etc), and makes it so that the fixture in use can be controlled via command-line flags: recording of new fixtures can be similarly controlled.

Use a particular fixture:

``` sh
bin/debug --fixture=fixture-dir-name
# or
bin/debug -f=fixture-dir-name
```

Record a new fixture:

``` sh
bin/debug --record -f=fixture-dir-name
# or
bin/debug -r -f=fixture-dir-name
```

`bin/debug [options]` can always be replaced by `npm run with-fixtures -- [options]`
