### PR TITLE
Improve green line handling and resolve loading state ambiguity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "5"
+  - "4"
   - "0.12"
-  - "0.11"
-  - "0.10"
+# Opt-in to travis container infrastructure
+sudo: false

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash.uniq": "^3.2.2",
     "lodash.without": "^3.2.1",
     "lru-cache": "^2.7.0",
-    "mbtapi": "^0.2.0",
+    "mbtapi": "^0.4.0",
     "minifyify": "^7.0.6",
     "morgan": "^1.6.1",
     "nodemon": "^1.4.1",

--- a/public/js/data/blue.js
+++ b/public/js/data/blue.js
@@ -163,6 +163,23 @@ var stations = [{
     id: '70042'
   }]
 }, {
+  name: 'Government Center',
+  station: 'place-gover',
+  transfer: [ 'green-b' ],
+  // position: {
+  //   lat: 42.359705,
+  //   lon: -71.059215
+  // },
+  stops: [{
+    dir: 0,
+    dirName: 'Westbound',
+    id: '70039'
+  }, {
+    dir: 1,
+    dirName: 'Eastbound',
+    id: '70040'
+  }]
+}, {
   name: 'Bowdoin',
   station: 'place-bomnl',
   // position: {

--- a/public/js/data/green-b.js
+++ b/public/js/data/green-b.js
@@ -2,6 +2,23 @@
 'use strict';
 
 var stations = [{
+  name: 'Government Center',
+  station: 'place-gover',
+  transfer: [ 'blue' ],
+  // position: {
+  //   lat: 42.359705,
+  //   lon: -71.059215
+  // },
+  stops: [{
+    dir: 0,
+    dirName: 'Westbound',
+    id: '70202'
+  }, {
+    dir: 1,
+    dirName: 'Eastbound',
+    id: '70201'
+  }]
+}, {
   name: 'Park Street',
   station: 'place-pktrm',
   transfer: [ 'red' ],

--- a/public/js/data/green-c.js
+++ b/public/js/data/green-c.js
@@ -36,6 +36,23 @@ var stations = [{
     id: '70203'
   }]
 }, {
+  name: 'Government Center',
+  station: 'place-gover',
+  transfer: [ 'blue' ],
+  // position: {
+  //   lat: 42.359705,
+  //   lon: -71.059215
+  // },
+  stops: [{
+    dir: 0,
+    dirName: 'Westbound',
+    id: '70202'
+  }, {
+    dir: 1,
+    dirName: 'Eastbound',
+    id: '70201'
+  }]
+}, {
   name: 'Park Street',
   station: 'place-pktrm',
   transfer: [ 'red' ],

--- a/public/js/data/green-d.js
+++ b/public/js/data/green-d.js
@@ -2,38 +2,21 @@
 'use strict';
 
 var stations = [{
-  name: 'North Station',
-  station: 'place-north',
-  transfer: [ 'orange', 'rail' ],
+  name: 'Government Center',
+  station: 'place-gover',
+  transfer: [ 'blue' ],
   // position: {
-  //   lat: 42.365577,
-  //   lon: -71.06129
+  //   lat: 42.359705,
+  //   lon: -71.059215
   // },
   stops: [{
     dir: 0,
     dirName: 'Westbound',
-    id: '70206'
+    id: '70202'
   }, {
     dir: 1,
     dirName: 'Eastbound',
-    id: '70205'
-  }]
-}, {
-  name: 'Haymarket',
-  station: 'place-haecl',
-  transfer: [ 'orange' ],
-  // position: {
-  //   lat: 42.363021,
-  //   lon: -71.05829
-  // },
-  stops: [{
-    dir: 0,
-    dirName: 'Westbound',
-    id: '70204'
-  }, {
-    dir: 1,
-    dirName: 'Eastbound',
-    id: '70203'
+    id: '70201'
   }]
 }, {
   name: 'Park Street',

--- a/public/js/data/green-e.js
+++ b/public/js/data/green-e.js
@@ -68,6 +68,23 @@ var stations = [{
     id: '70203'
   }]
 }, {
+  name: 'Government Center',
+  station: 'place-gover',
+  transfer: [ 'blue' ],
+  // position: {
+  //   lat: 42.359705,
+  //   lon: -71.059215
+  // },
+  stops: [{
+    dir: 0,
+    dirName: 'Westbound',
+    id: '70202'
+  }, {
+    dir: 1,
+    dirName: 'Eastbound',
+    id: '70201'
+  }]
+}, {
   name: 'Park Street',
   station: 'place-pktrm',
   transfer: [ 'red' ],

--- a/public/js/routes/green/green-line.tmpl
+++ b/public/js/routes/green/green-line.tmpl
@@ -6,45 +6,41 @@
   <hr class="divider-green" />
 
   <div class="green-line">
-    <h2>&hearts;</h2>
     <p>
-      <strong>Let&rsquo;s hear it for the T!</strong>
+      <strong>&hearts; Let&rsquo;s hear it for the T! &hearts;</strong><br>
       Limited Green Line real-time predictions are now available.
     </p>
-    <ul class="lines row">
+    <ul class="lines row half-columns">
       <li class="line three columns">
         <h2 class="line button green">
           <a href="/green-b">B Branch</a>
         </h2>
-        to Boston College
+        Boston College
       </li>
       <li class="line three columns">
         <h2 class="line button green">
           <a href="/green-c">C Branch</a>
         </h2>
-        to Cleveland Circle
+        Cleveland Circle
       </li>
       <li class="line three columns">
         <h2 class="line button green">
           <a href="/green-d">D Branch</a>
         </h2>
-        to Riverside
+        Riverside
       </li>
       <li class="line three columns">
         <h2 class="line button green">
           <a href="/green-e">E Branch</a>
         </h2>
-        to Heath St
+        Heath St
       </li>
     </ul>
+    <hr class="divider-green" />
     <p>
       It takes time to upgrade a subway system that&rsquo;s over a century and a half
       old, so predictions are not available for all stations just yet&mdash;but
       the rest are coming soon!
-    </p>
-    <p>
-      While we work on giving you a unified view of the stops between Kenmore and
-      North Station, each line can be viewed on its own now.
     </p>
   </div>
 </div>

--- a/public/js/routes/line-overview/index.js
+++ b/public/js/routes/line-overview/index.js
@@ -24,18 +24,20 @@ module.exports = {
 
   enter: function( opts ) {
     var lineSlug = opts.param.line;
+    // Green line data comes in unified blob, so for "green-X" get just "green"
+    var shortSlug = lineSlug.split( '-' )[ 0 ];
 
     // Look up the data with the line slug route parameter
     var line = _.findWhere( data.lines.models, {
       slug: lineSlug
     });
 
-    var trips = data.predictions.get( lineSlug );
+    var trips = data.predictions.get( shortSlug );
     if ( ! trips ) {
       trips = new TripsCollection([], {
-        line: lineSlug
+        line: shortSlug
       });
-      data.predictions.set( lineSlug, trips );
+      data.predictions.set( shortSlug, trips );
     }
 
     var alerts = data.alerts.get( lineSlug );

--- a/public/js/routes/station-detail/index.js
+++ b/public/js/routes/station-detail/index.js
@@ -23,6 +23,8 @@ module.exports = {
   enter: function( opts ) {
     /* jshint validthis: true */
     var lineSlug = opts.param.line;
+    // Green line data comes in unified blob, so for "green-X" get just "green"
+    var shortSlug = lineSlug.split( '-' )[ 0 ];
     var parentStation = opts.param.station;
 
     // Look up the data with the line slug route parameter
@@ -39,12 +41,13 @@ module.exports = {
       });
     }
 
-    var trips = data.predictions.get( lineSlug );
+    // Green line data comes in unified blob, so for "green-X" get just "green"
+    var trips = data.predictions.get( shortSlug );
     if ( ! trips ) {
       trips = new TripsCollection([], {
-        line: lineSlug
+        line: shortSlug
       });
-      data.predictions.set( lineSlug, trips );
+      data.predictions.set( shortSlug, trips );
     }
 
     var view = new StationDetailView({

--- a/public/js/routes/station-detail/models/direction-predictions.js
+++ b/public/js/routes/station-detail/models/direction-predictions.js
@@ -10,6 +10,11 @@ var DirectionPredictionsModel = Model.extend({
      */
     name: 'string',
     /**
+     * Whether this trips collection has loaded
+     * @property {Boolean} loaded
+     */
+    loaded: 'boolean',
+    /**
      * The trips going in this direction for which we have predictions
      * @property {Array} trips
      */

--- a/public/js/routes/station-detail/station-detail-view.js
+++ b/public/js/routes/station-detail/station-detail-view.js
@@ -79,6 +79,9 @@ var StationDetailView = View.extend({
           };
         });
 
+        // Pass through the "loaded" flag from the trips collection for UI state
+        var loaded = this.trips.loaded;
+
         // JFK UMass has two platforms, one for Braintree service and one for
         // Ashmont service: to properly account for these, we need to do one
         // final grouping and mapping action to merge the trip lists for
@@ -89,7 +92,8 @@ var StationDetailView = View.extend({
           return {
             dir: direction.dir,
             name: direction.name,
-            trips: tripsForDirection
+            trips: tripsForDirection,
+            loaded: loaded
           };
         });
 
@@ -113,7 +117,6 @@ var StationDetailView = View.extend({
    */
   _triggerPredictionsChange: function() {
     this.trigger( 'change:trips' );
-    window.tbd = this.tripsByDirection;
   },
 
   render: function() {

--- a/public/js/routes/station-detail/station-detail.tmpl
+++ b/public/js/routes/station-detail/station-detail.tmpl
@@ -16,10 +16,10 @@
     {%if transfer | supported-line %}
     <a href="/{{ transfer | transfer-station station.station }}">
     {%endif %}
-    <span class="xfer-icon xfer-{{ transfer }}" title="{{ transfer | capitalize }} Line">
-      <span class="sr">{{ transfer | capitalize }} Line</span>
+    <span class="xfer-icon xfer-{{ transfer | get-color }}" title="{{ transfer | get-color | capitalize }} Line">
+      <span class="sr">{{ transfer | get-color | capitalize }} Line</span>
     </span>
-    {%if transfer | supported-line %}
+    {%if transfer | get-color | supported-line %}
     </a>
     {%endif %}
     {%endeach %}

--- a/public/js/routes/station-detail/trip-predictions-list-view.js
+++ b/public/js/routes/station-detail/trip-predictions-list-view.js
@@ -18,6 +18,12 @@ var PredictionsListView = jQueryView.extend({
         return this.model.name;
       }
     },
+    loaded: {
+      deps: [ 'model.loaded' ],
+      fn: function() {
+        return this.model.loaded;
+      }
+    },
     trips: {
       deps: [ 'model.trips' ],
       fn: function() {

--- a/public/js/routes/station-detail/trip-predictions-list.tmpl
+++ b/public/js/routes/station-detail/trip-predictions-list.tmpl
@@ -42,6 +42,15 @@
         </td>
       </tr>
       {%endif %}
+    {%elsif not loaded %}
+      <tr>
+        <td colspan="2">
+          <div class="loading-spinner inline">
+            <div class="rotating-plane small-spinner"></div>
+          </div>
+          <em>Loading &hellip;</em>
+        </td>
+      </tr>
     {%else %}
       <tr>
         <td colspan="2">

--- a/public/stylus/app.styl
+++ b/public/stylus/app.styl
@@ -196,6 +196,24 @@ coloring( $color ) {
   }
 }
 
+// Green line custom half-width buttons
+
+.half-columns {
+  +respond-below($md-screen) {
+    .columns {
+      width: 48%;
+      clear: right;
+      &:nth-of-type(2n) {
+        float: right;
+      }
+
+      +respond-above($sm-screen) {
+        margin: 0 0 1em 0;
+      }
+    }
+  }
+}
+
 .station,
 .line {
   list-style-type: none;

--- a/server/routes/green-line.js
+++ b/server/routes/green-line.js
@@ -11,7 +11,7 @@ var mbtapi = require( '../services/api' );
 function lineOverviewRoute( req, res, next ) {
 
   // Prime API cache
-  mbtapi.alertsByLine( 'green' );
+  mbtapi.predictionsByLine( 'green' );
 
   // Determine the title
   var title = pageTitle([

--- a/server/routes/line-overview.js
+++ b/server/routes/line-overview.js
@@ -18,6 +18,7 @@ function lineOverviewRoute( req, res, next ) {
   }
 
   // Prime API cache
+  mbtapi.alertsByLine( line );
   mbtapi.predictionsByLine( line );
 
   // Determine the title

--- a/server/services/api/index.js
+++ b/server/services/api/index.js
@@ -76,7 +76,6 @@ function predictionsByLine( lineSlug ) {
   }
 
   if ( lineSlug === 'green' ) {
-    console.log('foo');
     return predictionsByRoutes( validLines.greenLineRoutes ).then(function( results ) {
       // "route_type": "0",
       //   "mode_name": "Subway",

--- a/server/services/valid-lines.js
+++ b/server/services/valid-lines.js
@@ -13,6 +13,7 @@ var validLines = [
   'blue',
   'orange',
   'red',
+  'green',
   'green-b',
   'green-c',
   'green-d',
@@ -46,6 +47,7 @@ function format( routeId ) {
 
 module.exports = {
   list: validLines,
+  greenLineRoutes: [ 'Green-B', 'Green-C', 'Green-D', 'Green-E' ],
   invalid: invalid,
   format: format
 };


### PR DESCRIPTION
- Reinstate Government Center Station in the Green Line predictions lists
- Update Green Line overview pages to have smaller, 2x2 buttons (design tweak only)
- Show trains for all destinations are multi-branch green line stops (#57)
- Show a loading indicator before data has been retrieved for a line (#22)
